### PR TITLE
Improve API transforms, outgoing chat UX, and book/lobby translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ nb-configuration.xml
 nbproject/
 /db/
 devtools/
+WhatsApp Video*.mp4

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ nbactions.xml
 nb-configuration.xml
 nbproject/
 /db/
+devtools/

--- a/build.gradle
+++ b/build.gradle
@@ -39,16 +39,15 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 tasks.register('shadowJar', Jar) {
-	dependsOn configurations.testRuntimeClasspath
+	dependsOn configurations.runtimeClasspath
 	manifest {
 		attributes('Main-Class': 'com.example.ExamplePluginTest', 'Multi-Release': true)
 	}
 
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 	from sourceSets.main.output
-	from sourceSets.test.output
 	from {
-		configurations.testRuntimeClasspath.collect { file ->
+		configurations.runtimeClasspath.collect { file ->
 			file.isDirectory() ? file : zipTree(file)
 		}
 	}
@@ -57,7 +56,13 @@ tasks.register('shadowJar', Jar) {
 	exclude 'META-INF/*.SF'
 	exclude 'META-INF/*.DSA'
 	exclude 'META-INF/*.RSA'
+	exclude 'META-INF/versions/**'
 	exclude '**/module-info.class'
+	// Remove H2 web/servlet classes; RuneLite's plugin classpath does not include servlet APIs.
+	exclude 'org/h2/server/web/**'
+	// Remove optional H2 OSGi integrations; RuneLite does not provide OSGi classes.
+	exclude 'org/h2/util/DbDriverActivator.class'
+	exclude 'org/h2/util/OsgiDataSourceFactory.class'
 
 	group = BasePlugin.BUILD_GROUP
 	archiveClassifier.set('shadow')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.9"
+
+services:
+  libretranslate:
+    image: libretranslate/libretranslate:latest
+    container_name: libretranslate
+    restart: unless-stopped
+    user: root
+    ports:
+      - "5000:5000"
+    environment:
+      # Keep only the languages we care about to reduce model downloads.
+      # Codes should match what the LibreTranslate instance reports at GET /languages.
+      - LT_LOAD_ONLY=en,pt-BR
+      - LT_CHAR_LIMIT=1000
+      - LT_REQ_LIMIT=0
+      - LT_BATCH_LIMIT=0
+      - LT_FRONTEND_LANGUAGE=pt
+      - LT_API_KEYS=false
+      - LT_SUGGESTIONS=false
+      - LT_DISABLE_FILES_TRANSLATION=true
+      - LT_DISABLE_WEB_UI=true
+      - LT_THREADS=4
+    volumes:
+      - lt-data:/home/libretranslate/.local/share
+      - lt-cache:/home/libretranslate/.local/cache
+    tmpfs:
+      - /tmp
+    deploy:
+      resources:
+        limits:
+          memory: 3G
+
+volumes:
+  lt-data:
+  lt-cache:

--- a/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
+++ b/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
@@ -25,6 +25,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -32,6 +33,14 @@ import javax.inject.Inject;
 
 @Slf4j
 public class Deepl {
+    private static final int DEEPL_MAX_HEADER_BYTES = 16 * 1024;
+    private static final int DEEPL_MAX_TOTAL_REQUEST_BYTES = 128 * 1024;
+    private static final int DEEPL_FREE_MONTHLY_CHAR_LIMIT = 500_000;
+    private static final int DEEPL_MONTHLY_LIMIT_SAFETY_BUFFER = 1000;
+    private static final long USAGE_REFRESH_INTERVAL_MILLIS = 60_000L;
+    private static final long RATE_LIMIT_BACKOFF_MILLIS = 10_000L;
+    private static final long GENERIC_BACKOFF_MILLIS = 5_000L;
+
     @Inject
     private RuneLingualPlugin plugin;
     @Inject
@@ -51,6 +60,9 @@ public class Deepl {
     private static final MediaType mediaType = MediaType.parse("Content-Type: application/json");
 
     private ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private volatile long lastUsageRefreshMillis = 0L;
+    private volatile long globalRetryNotBeforeMillis = 0L;
+    private final Map<String, Long> textRetryNotBeforeMillis = new ConcurrentHashMap<>();
 
     private final Object apiStateLock = new Object();
     private volatile int apiStateVersion = 0; // Tracks the current state version of the API
@@ -83,6 +95,9 @@ public class Deepl {
         if(!plugin.getConfig().ApiConfig()){
             return text;
         }
+        if (isRetryCoolingDown(text)) {
+            return text;
+        }
         // if the text is already translated, return the past translation
         String pastTranslation = deeplPastTranslationManager.getPastTranslation(text);
         if (pastTranslation != null) {
@@ -96,13 +111,12 @@ public class Deepl {
         deeplKey = plugin.getConfig().getAPIKey();
 
         setUsageAndLimit();
-        //if the character count is close to the limit, return the original text
-        if(deeplCount > deeplLimit - text.length() - 1000){
+        int billedCharacters = countTextCharacters(text);
+        int effectiveLimit = getEffectiveMonthlyCharacterLimit();
+        // if the character count is close to the limit, return the original text
+        if(deeplCount > effectiveLimit - billedCharacters - DEEPL_MONTHLY_LIMIT_SAFETY_BUFFER){
             return text;
         }
-
-        // from here, attempt to translate the text
-        translationAttempt.add(text);
 
 
         String url = getTranslatorUrl();
@@ -111,17 +125,27 @@ public class Deepl {
         }
 
         JsonObject urlParameters = getUrlParameters(sourceLang, targetLang, text);
+        RequestBody requestBody = FormBody.create(mediaType, urlParameters.toString());
+        long requestBodyBytes = getRequestBodyBytes(requestBody);
+        if (requestBodyBytes > DEEPL_MAX_TOTAL_REQUEST_BYTES) {
+            log.warn("Skipping DeepL request: request body too large ({} bytes, max {} bytes).",
+                    requestBodyBytes, DEEPL_MAX_TOTAL_REQUEST_BYTES);
+            return text;
+        }
 
-        getResponse(url, FormBody.create(mediaType, urlParameters.toString()), new ResponseCallback() {
+        // from here, attempt to translate the text
+        translationAttempt.add(text);
+
+        getResponse(url, requestBody, new ResponseCallback() {
             @Override
             public void onSuccess(String response) {
+                translationAttempt.remove(text);
                 setUsageAndLimit();
                 String translation = getTranslationInResponse(response);
                 if (!translation.isEmpty()) {
                     // add the new translation to the past translations and its file
                     deeplPastTranslationManager.addToPastTranslations(text, translation);
                     setKeyValid(true);
-                    translationAttempt.remove(text);
                 }
 
             }
@@ -129,6 +153,8 @@ public class Deepl {
             @Override
             public void onFailure(Exception error) {
                 setKeyValid(false);
+                translationAttempt.remove(text);
+                scheduleRetryBackoff(text, error);
                 handleError(error);
             }
 
@@ -141,8 +167,37 @@ public class Deepl {
         return text; // return original text while the translation is being processed in the thread
     }
 
+    /**
+     * Attempts to translate and waits for async API completion up to timeoutMillis.
+     * Returns original text when timeout or error happens.
+     */
+    public String translateBlocking(String text, LangCodeSelectableList sourceLang, LangCodeSelectableList targetLang, long timeoutMillis) {
+        String immediate = translate(text, sourceLang, targetLang);
+        if (!Objects.equals(immediate, text) && !immediate.isBlank()) {
+            return immediate;
+        }
+
+        long deadline = System.currentTimeMillis() + Math.max(timeoutMillis, 0);
+        while (System.currentTimeMillis() < deadline) {
+            String pastTranslation = deeplPastTranslationManager.getPastTranslation(text);
+            if (pastTranslation != null && !Objects.equals(pastTranslation, text) && !pastTranslation.isBlank()) {
+                return pastTranslation;
+            }
+
+            try {
+                Thread.sleep(50L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        return text;
+    }
+
     private JsonObject getUrlParameters(LangCodeSelectableList sourceLang, LangCodeSelectableList targetLang, String text) {
         String targetLangCode = targetLang.getDeeplLangCodeTarget();
+        String sourceLangCode = sourceLang.getDeeplLangCodeSource();
         JsonArray jsonArray = new JsonArray();
         jsonArray.add(text);
 
@@ -153,7 +208,7 @@ public class Deepl {
         jsonObject.addProperty("split_sentences", "nonewlines");
         jsonObject.addProperty("preserve_formatting", true);
         jsonObject.addProperty("formality", "prefer_less");
-        jsonObject.addProperty("source_lang", "EN");
+        jsonObject.addProperty("source_lang", sourceLangCode);
 
         return jsonObject;
     }
@@ -214,7 +269,23 @@ public class Deepl {
                     .url(url)
                     .post(requestBody);
 
-            httpClient.newCall(request.build()).enqueue(new Callback() {
+            Request builtRequest = request.build();
+            long headerBytes = getHeaderBytes(builtRequest);
+            long requestBodyBytes = getRequestBodyBytes(requestBody);
+            long totalRequestBytes = headerBytes + requestBodyBytes;
+
+            if (headerBytes > DEEPL_MAX_HEADER_BYTES) {
+                callback.onFailure(new IOException(
+                        String.format("DeepL request header too large: %d bytes (max %d)", headerBytes, DEEPL_MAX_HEADER_BYTES)));
+                return;
+            }
+            if (totalRequestBytes > DEEPL_MAX_TOTAL_REQUEST_BYTES) {
+                callback.onFailure(new IOException(
+                        String.format("DeepL request too large: %d bytes (max %d)", totalRequestBytes, DEEPL_MAX_TOTAL_REQUEST_BYTES)));
+                return;
+            }
+
+            httpClient.newCall(builtRequest).enqueue(new Callback() {
                 @Override
                 public void onFailure(Call call, IOException error) {
                     synchronized (apiStateLock) {
@@ -224,23 +295,15 @@ public class Deepl {
                         }
                     }
                     if (retryCount < 5) {
-                        int delay = new Random().nextInt(8) + 3;
-                        synchronized (apiStateLock) {
-                            if (currentVersion != apiStateVersion || !plugin.getConfig().ApiConfig()) {
-                                //log.info("Discarding outdated retry scheduling due to API state change.");
-                                return;
-                            }
-                        }
-                        //log.info("on failure: Retrying API request in {} seconds (attempt {})", delay, retryCount + 1);
+                        long delaySeconds = getRetryDelaySeconds();
                         scheduler.schedule(() -> {
                             synchronized (apiStateLock) {
                                 if (currentVersion != apiStateVersion || !plugin.getConfig().ApiConfig()) {
-                                    //log.info("Discarding outdated retry execution due to API state change.");
                                     return;
                                 }
                             }
                             getResponseWithRetry(url, requestBody, callback, retryCount + 1);
-                        }, delay, TimeUnit.SECONDS);
+                        }, delaySeconds, TimeUnit.SECONDS);
                     } else {
                         callback.onFailure(error);
                     }
@@ -255,36 +318,43 @@ public class Deepl {
                         }
                     }
                     try (ResponseBody responseBody = response.body()) {
-                        if (responseBody != null) {
-                            String responseBodyString = responseBody.string();
-                            if (response.code() == 429) { // Too Many Requests
-                                if (retryCount < 5) {
-                                    int delay = new Random().nextInt(8) + 3;
+                        if (responseBody == null) {
+                            callback.onFailure(new IOException("Response body is null"));
+                            return;
+                        }
+
+                        String responseBodyString = responseBody.string();
+                        int responseCode = response.code();
+                        boolean isCongestionCode = responseCode == 429 || responseCode == 503 || responseCode == 529;
+
+                        if (isCongestionCode) {
+                            setGlobalRetryBackoff(System.currentTimeMillis() + RATE_LIMIT_BACKOFF_MILLIS);
+                            if (retryCount < 5) {
+                                long delaySeconds = getRetryDelaySeconds();
+                                scheduler.schedule(() -> {
                                     synchronized (apiStateLock) {
                                         if (currentVersion != apiStateVersion || !plugin.getConfig().ApiConfig()) {
-                                            //log.info("Discarding outdated retry scheduling due to API state change.");
                                             return;
                                         }
                                     }
-                                    //log.info("on response: Retrying API request in {} seconds (attempt {})", delay, retryCount + 1);
-                                    scheduler.schedule(() -> {
-                                        synchronized (apiStateLock) {
-                                            if (currentVersion != apiStateVersion || !plugin.getConfig().ApiConfig()) {
-                                                //log.info("Discarding outdated retry execution due to API state change.");
-                                                return;
-                                            }
-                                        }
-                                        getResponseWithRetry(url, requestBody, callback, retryCount + 1);
-                                    }, delay, TimeUnit.SECONDS);
-                                } else {
-                                    callback.onFailure(new IOException("Too many requests"));
-                                }
-                            } else {
-                                callback.onSuccess(responseBodyString);
+                                    getResponseWithRetry(url, requestBody, callback, retryCount + 1);
+                                }, delaySeconds, TimeUnit.SECONDS);
+                                return;
                             }
-                        } else {
-                            callback.onFailure(new IOException("Response body is null"));
+                            callback.onFailure(new IOException("DeepL congestion/rate limit: HTTP " + responseCode));
+                            return;
                         }
+
+                        if (!response.isSuccessful()) {
+                            String message = responseBodyString;
+                            if (message.length() > 300) {
+                                message = message.substring(0, 300) + "...";
+                            }
+                            callback.onFailure(new IOException("DeepL HTTP " + responseCode + ": " + message));
+                            return;
+                        }
+
+                        callback.onSuccess(responseBodyString);
                     } catch (Exception error) {
                         callback.onFailure(error);
                     }
@@ -321,7 +391,20 @@ public class Deepl {
 
     // function to set usage of the API
     public void setUsageAndLimit() {
-        getResponse(getUsageUrl(), FormBody.create(mediaType, ""), new ResponseCallback() {
+        String usageUrl = getUsageUrl();
+        if (usageUrl.isEmpty()) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        if (now < globalRetryNotBeforeMillis) {
+            return;
+        }
+        if (now - lastUsageRefreshMillis < USAGE_REFRESH_INTERVAL_MILLIS) {
+            return;
+        }
+        lastUsageRefreshMillis = now;
+
+        getResponse(usageUrl, FormBody.create(mediaType, ""), new ResponseCallback() {
             @Override
             public void onSuccess(String usage) {
                 if (usage.isEmpty()) {
@@ -347,6 +430,7 @@ public class Deepl {
 
             @Override
             public void onFailure(Exception error) {
+                lastUsageRefreshMillis = System.currentTimeMillis() - USAGE_REFRESH_INTERVAL_MILLIS + 5000L;
                 handleError(error);
             }
 
@@ -355,5 +439,90 @@ public class Deepl {
                 //log.info("API is disabled");
             }
         });
+    }
+
+    private boolean isRetryCoolingDown(String text) {
+        long now = System.currentTimeMillis();
+        if (now < globalRetryNotBeforeMillis) {
+            return true;
+        }
+        Long textRetryNotBefore = textRetryNotBeforeMillis.get(text);
+        if (textRetryNotBefore == null) {
+            return false;
+        }
+        if (textRetryNotBefore > now) {
+            return true;
+        }
+        textRetryNotBeforeMillis.remove(text);
+        return false;
+    }
+
+    private void scheduleRetryBackoff(String text, Exception error) {
+        long now = System.currentTimeMillis();
+        String message = error == null || error.getMessage() == null
+                ? ""
+                : error.getMessage().toLowerCase(Locale.ROOT);
+
+        boolean isCongestion = message.contains("429")
+                || message.contains("too many requests")
+                || message.contains("congestion")
+                || message.contains("rate limit")
+                || message.contains("503")
+                || message.contains("529");
+
+        long backoffMillis = isCongestion ? RATE_LIMIT_BACKOFF_MILLIS : GENERIC_BACKOFF_MILLIS;
+        textRetryNotBeforeMillis.put(text, now + backoffMillis);
+        if (isCongestion) {
+            setGlobalRetryBackoff(now + RATE_LIMIT_BACKOFF_MILLIS);
+        }
+    }
+
+    private void setGlobalRetryBackoff(long notBeforeMillis) {
+        if (notBeforeMillis > globalRetryNotBeforeMillis) {
+            globalRetryNotBeforeMillis = notBeforeMillis;
+        }
+    }
+
+    private long getRetryDelaySeconds() {
+        return new Random().nextInt(8) + 3;
+    }
+
+    private int getEffectiveMonthlyCharacterLimit() {
+        int configuredLimit = deeplLimit > 0 ? deeplLimit : DEEPL_FREE_MONTHLY_CHAR_LIMIT;
+        if (Objects.equals(config.getApiServiceConfig().getServiceName(), TranslatingServiceSelectableList.DeepL.getServiceName())) {
+            return Math.min(configuredLimit, DEEPL_FREE_MONTHLY_CHAR_LIMIT);
+        }
+        return configuredLimit;
+    }
+
+    private int countTextCharacters(String text) {
+        if (text == null || text.isEmpty()) {
+            return 0;
+        }
+        return text.codePointCount(0, text.length());
+    }
+
+    private long getRequestBodyBytes(RequestBody requestBody) {
+        try {
+            long contentLength = requestBody.contentLength();
+            return contentLength < 0 ? DEEPL_MAX_TOTAL_REQUEST_BYTES + 1L : contentLength;
+        } catch (IOException e) {
+            return DEEPL_MAX_TOTAL_REQUEST_BYTES + 1L;
+        }
+    }
+
+    private long getHeaderBytes(Request request) {
+        long bytes = 0L;
+        Headers headers = request.headers();
+        for (int i = 0; i < headers.size(); i++) {
+            String name = headers.name(i);
+            String value = headers.value(i);
+            bytes += name.getBytes(StandardCharsets.UTF_8).length;
+            bytes += 2; // ": "
+            bytes += value.getBytes(StandardCharsets.UTF_8).length;
+            bytes += 2; // CRLF
+        }
+        bytes += 2; // final CRLF
+        return bytes;
     }
 }

--- a/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
+++ b/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
@@ -110,12 +110,17 @@ public class Deepl {
         }
         deeplKey = plugin.getConfig().getAPIKey();
 
-        setUsageAndLimit();
-        int billedCharacters = countTextCharacters(text);
-        int effectiveLimit = getEffectiveMonthlyCharacterLimit();
-        // if the character count is close to the limit, return the original text
-        if(deeplCount > effectiveLimit - billedCharacters - DEEPL_MONTHLY_LIMIT_SAFETY_BUFFER){
-            return text;
+        if (isDeepLServiceSelected()) {
+            setUsageAndLimit();
+            int billedCharacters = countTextCharacters(text);
+            int effectiveLimit = getEffectiveMonthlyCharacterLimit();
+            // if the character count is close to the limit, return the original text
+            if(deeplCount > effectiveLimit - billedCharacters - DEEPL_MONTHLY_LIMIT_SAFETY_BUFFER){
+                return text;
+            }
+        } else {
+            // Non-DeepL providers do not expose DeepL usage/quota semantics.
+            keyValid = true;
         }
 
 
@@ -152,7 +157,9 @@ public class Deepl {
 
             @Override
             public void onFailure(Exception error) {
-                setKeyValid(false);
+                if (isDeepLServiceSelected()) {
+                    setKeyValid(false);
+                }
                 translationAttempt.remove(text);
                 scheduleRetryBackoff(text, error);
                 handleError(error);
@@ -196,19 +203,32 @@ public class Deepl {
     }
 
     private JsonObject getUrlParameters(LangCodeSelectableList sourceLang, LangCodeSelectableList targetLang, String text) {
-        String targetLangCode = targetLang.getDeeplLangCodeTarget();
-        String sourceLangCode = sourceLang.getDeeplLangCodeSource();
-        JsonArray jsonArray = new JsonArray();
-        jsonArray.add(text);
-
         JsonObject jsonObject = new JsonObject();
-        jsonObject.add("text", jsonArray);
-        jsonObject.addProperty("target_lang", targetLangCode);
-        jsonObject.addProperty("context", "runescape; dungeons and dragons; medieval fantasy;");
-        jsonObject.addProperty("split_sentences", "nonewlines");
-        jsonObject.addProperty("preserve_formatting", true);
-        jsonObject.addProperty("formality", "prefer_less");
-        jsonObject.addProperty("source_lang", sourceLangCode);
+        String targetLangCode = getLanguageCodeForService(targetLang, false);
+        String sourceLangCode = getLanguageCodeForService(sourceLang, true);
+
+        if (isDeepLServiceSelected()) {
+            JsonArray jsonArray = new JsonArray();
+            jsonArray.add(text);
+            jsonObject.add("text", jsonArray);
+            jsonObject.addProperty("target_lang", targetLangCode);
+            jsonObject.addProperty("context", "runescape; dungeons and dragons; medieval fantasy;");
+            jsonObject.addProperty("split_sentences", "nonewlines");
+            jsonObject.addProperty("preserve_formatting", true);
+            jsonObject.addProperty("formality", "prefer_less");
+            jsonObject.addProperty("source_lang", sourceLangCode);
+            return jsonObject;
+        }
+
+        if (isLibreTranslateServiceSelected()) {
+            jsonObject.addProperty("q", text);
+            jsonObject.addProperty("source", sourceLangCode);
+            jsonObject.addProperty("target", targetLangCode);
+            jsonObject.addProperty("format", "text");
+            if (deeplKey != null && !deeplKey.isEmpty()) {
+                jsonObject.addProperty("api_key", deeplKey);
+            }
+        }
 
         return jsonObject;
     }
@@ -218,25 +238,58 @@ public class Deepl {
         if(baseUrl.isEmpty()){
             return "";
         }
-        return baseUrl + "translate";
+        return baseUrl + "/translate";
     }
 
     private String getUsageUrl() {
+        if (!isDeepLServiceSelected()) {
+            return "";
+        }
         String baseUrl = getBaseUrl();
         if(baseUrl.isEmpty()){
             return "";
         }
-        return baseUrl + "usage";
+        return baseUrl + "/usage";
     }
 
     private String getBaseUrl() {
-        if (Objects.equals(config.getApiServiceConfig().getServiceName(), TranslatingServiceSelectableList.DeepL.getServiceName())) {
-            return "https://api-free.deepl.com/v2/";
-        } else if (Objects.equals(config.getApiServiceConfig().getServiceName(), TranslatingServiceSelectableList.DeepL_PRO.getServiceName())) {
-            return "https://api.deepl.com/v2/";
+        if (isDeepLFreeServiceSelected()) {
+            return "https://api-free.deepl.com/v2";
+        } else if (isDeepLProServiceSelected()) {
+            return "https://api.deepl.com/v2";
+        } else if (isLibreTranslateServiceSelected()) {
+            String configuredUrl = config.getLibreTranslateUrl();
+            if (configuredUrl == null) {
+                return "";
+            }
+            String trimmed = configuredUrl.trim();
+            if (trimmed.isEmpty()) {
+                return "";
+            }
+            while (trimmed.endsWith("/")) {
+                trimmed = trimmed.substring(0, trimmed.length() - 1);
+            }
+            return trimmed;
         } else {
             return "";
         }
+    }
+
+    private String getLanguageCodeForService(LangCodeSelectableList lang, boolean isSource) {
+        if (isDeepLServiceSelected()) {
+            return isSource ? lang.getDeeplLangCodeSource() : lang.getDeeplLangCodeTarget();
+        }
+        if (isLibreTranslateServiceSelected()) {
+            String langCode = lang.getLangCode();
+            if ("pt_br".equalsIgnoreCase(langCode) || "pt".equalsIgnoreCase(langCode)) {
+                return "pt";
+            }
+            if ("no".equalsIgnoreCase(langCode)) {
+                return "nb";
+            }
+            return langCode.replace('_', '-').toLowerCase(Locale.ROOT);
+        }
+        return lang.getLangCode();
     }
 
     private void getResponse(String url, RequestBody requestBody, ResponseCallback callback) {
@@ -254,7 +307,7 @@ public class Deepl {
             return;
         }
 
-        if (deeplKey == null || deeplKey.isEmpty()) {
+        if (isDeepLServiceSelected() && (deeplKey == null || deeplKey.isEmpty())) {
             callback.onFailure(new IOException("API key is missing"));
             return;
         }
@@ -262,12 +315,17 @@ public class Deepl {
         try {
             Request.Builder request = new Request.Builder()
                     .addHeader("User-Agent", RuneLite.USER_AGENT + " (runelingual)")
-                    .addHeader("Authorization", "DeepL-Auth-Key " + deeplKey)
                     .addHeader("Accept", "application/json")
                     .addHeader("Content-Type", "application/json")
-                    .addHeader("Content-Length", String.valueOf(requestBody.contentLength()))
                     .url(url)
                     .post(requestBody);
+            if (isDeepLServiceSelected()) {
+                request.addHeader("Authorization", "DeepL-Auth-Key " + deeplKey);
+            }
+            long contentLength = requestBody.contentLength();
+            if (contentLength >= 0L) {
+                request.addHeader("Content-Length", String.valueOf(contentLength));
+            }
 
             Request builtRequest = request.build();
             long headerBytes = getHeaderBytes(builtRequest);
@@ -341,7 +399,7 @@ public class Deepl {
                                 }, delaySeconds, TimeUnit.SECONDS);
                                 return;
                             }
-                            callback.onFailure(new IOException("DeepL congestion/rate limit: HTTP " + responseCode));
+                            callback.onFailure(new IOException("Translation API congestion/rate limit: HTTP " + responseCode));
                             return;
                         }
 
@@ -350,7 +408,7 @@ public class Deepl {
                             if (message.length() > 300) {
                                 message = message.substring(0, 300) + "...";
                             }
-                            callback.onFailure(new IOException("DeepL HTTP " + responseCode + ": " + message));
+                            callback.onFailure(new IOException("Translation API HTTP " + responseCode + ": " + message));
                             return;
                         }
 
@@ -367,7 +425,7 @@ public class Deepl {
     }
 
     private void handleError(Exception error) {
-        log.error("Failed to get response from DeepL API.", error);
+        log.error("Failed to get response from translation API {}.", config.getApiServiceConfig(), error);
     }
 
 
@@ -379,6 +437,17 @@ public class Deepl {
 
     private String getTranslationInResponse(String response) {
         JSONObject jsonObject = new JSONObject(response);
+        if (jsonObject.has("translatedText")) {
+            Object translatedText = jsonObject.get("translatedText");
+            if (translatedText instanceof JSONArray) {
+                JSONArray arr = (JSONArray) translatedText;
+                if (arr.length() > 0) {
+                    return arr.getString(0);
+                }
+            } else if (translatedText != null) {
+                return translatedText.toString();
+            }
+        }
         if (jsonObject.has("translations")) {
             JSONArray translationsArray = jsonObject.getJSONArray("translations");
             if (translationsArray != null && translationsArray.length() > 0) { // .length() > 0 is used instead of ! .isEmpty() because .isEmpty on JsonObject doesnt work on the runelite client for some reason
@@ -391,6 +460,12 @@ public class Deepl {
 
     // function to set usage of the API
     public void setUsageAndLimit() {
+        if (!isDeepLServiceSelected()) {
+            keyValid = true;
+            deeplCount = 0;
+            deeplLimit = Integer.MAX_VALUE;
+            return;
+        }
         String usageUrl = getUsageUrl();
         if (usageUrl.isEmpty()) {
             return;
@@ -491,26 +566,58 @@ public class Deepl {
         if (!plugin.getConfig().ApiConfig()) {
             return false;
         }
-        deeplKey = plugin.getConfig().getAPIKey();
-        if (deeplKey == null || deeplKey.isEmpty()) {
+        if (System.currentTimeMillis() < globalRetryNotBeforeMillis) {
             return false;
+        }
+        if (isDeepLServiceSelected()) {
+            deeplKey = plugin.getConfig().getAPIKey();
+            if (deeplKey == null || deeplKey.isEmpty()) {
+                return false;
+            }
+            if (!keyValid) {
+                return false;
+            }
+            int effectiveLimit = getEffectiveMonthlyCharacterLimit();
+            return deeplCount <= effectiveLimit - DEEPL_MONTHLY_LIMIT_SAFETY_BUFFER;
+        }
+        if (isLibreTranslateServiceSelected()) {
+            return !getTranslatorUrl().isEmpty();
         }
         if (!keyValid) {
             return false;
         }
-        if (System.currentTimeMillis() < globalRetryNotBeforeMillis) {
-            return false;
-        }
-        int effectiveLimit = getEffectiveMonthlyCharacterLimit();
-        return deeplCount <= effectiveLimit - DEEPL_MONTHLY_LIMIT_SAFETY_BUFFER;
+        return !getTranslatorUrl().isEmpty();
     }
 
     private int getEffectiveMonthlyCharacterLimit() {
+        if (!isDeepLServiceSelected()) {
+            return Integer.MAX_VALUE;
+        }
         int configuredLimit = deeplLimit > 0 ? deeplLimit : DEEPL_FREE_MONTHLY_CHAR_LIMIT;
-        if (Objects.equals(config.getApiServiceConfig().getServiceName(), TranslatingServiceSelectableList.DeepL.getServiceName())) {
+        if (isDeepLFreeServiceSelected()) {
             return Math.min(configuredLimit, DEEPL_FREE_MONTHLY_CHAR_LIMIT);
         }
         return configuredLimit;
+    }
+
+    public boolean usesDeepLUsageLimits() {
+        return isDeepLServiceSelected();
+    }
+
+    private boolean isDeepLServiceSelected() {
+        return config.getApiServiceConfig().isDeepLFamily();
+    }
+
+    private boolean isDeepLFreeServiceSelected() {
+        return config.getApiServiceConfig() == TranslatingServiceSelectableList.DeepL;
+    }
+
+    private boolean isDeepLProServiceSelected() {
+        return config.getApiServiceConfig() == TranslatingServiceSelectableList.DeepL_PRO;
+    }
+
+    private boolean isLibreTranslateServiceSelected() {
+        return config.getApiServiceConfig() == TranslatingServiceSelectableList.LibreTranslate;
     }
 
     private int countTextCharacters(String text) {

--- a/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
+++ b/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Inject;
 
 @Slf4j
@@ -66,6 +67,11 @@ public class Deepl {
 
     private final Object apiStateLock = new Object();
     private volatile int apiStateVersion = 0; // Tracks the current state version of the API
+
+    // LibreTranslate doesn't provide a standard /usage endpoint.
+    // Track local usage so the overlay can show something meaningful.
+    private final AtomicLong libreTranslateCharCount = new AtomicLong(0L);
+    private final AtomicLong libreTranslateRequestCount = new AtomicLong(0L);
 
     // add texts that has already been attempted to be translated.
     // this avoids translating same texts multiple times when ran in a thread, which will waste limited or paid word count
@@ -146,6 +152,7 @@ public class Deepl {
             apiDebugLog("Skip translate: no API URL configured (service={})", config.getApiServiceConfig());
             return text;
         }
+        final TranslatingServiceSelectableList serviceAtQueue = config.getApiServiceConfig();
 
         JsonObject urlParameters = getUrlParameters(sourceLang, targetLang, text);
         RequestBody requestBody = FormBody.create(mediaType, urlParameters.toString());
@@ -172,6 +179,9 @@ public class Deepl {
             public void onSuccess(String response) {
                 translationAttempt.remove(text);
                 setUsageAndLimit();
+                if (serviceAtQueue == TranslatingServiceSelectableList.LibreTranslate) {
+                    recordLibreTranslateUsage(text);
+                }
                 String translation = getTranslationInResponse(response);
                 if (!translation.isEmpty()) {
                     // add the new translation to the past translations and its file
@@ -212,6 +222,19 @@ public class Deepl {
         });
 
         return text; // return original text while the translation is being processed in the thread
+    }
+
+    public long getLibreTranslateCharCount() {
+        return libreTranslateCharCount.get();
+    }
+
+    public long getLibreTranslateRequestCount() {
+        return libreTranslateRequestCount.get();
+    }
+
+    private void recordLibreTranslateUsage(String text) {
+        libreTranslateRequestCount.incrementAndGet();
+        libreTranslateCharCount.addAndGet(countTextCharacters(text));
     }
 
     /**

--- a/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
+++ b/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
@@ -321,7 +321,10 @@ public class Deepl {
         }
         if (isLibreTranslateServiceSelected()) {
             String langCode = lang.getLangCode();
-            if ("pt_br".equalsIgnoreCase(langCode) || "pt".equalsIgnoreCase(langCode)) {
+            if ("pt_br".equalsIgnoreCase(langCode)) {
+                return "pt-BR";
+            }
+            if ("pt".equalsIgnoreCase(langCode)) {
                 return "pt";
             }
             if ("no".equalsIgnoreCase(langCode)) {

--- a/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
+++ b/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
@@ -118,9 +118,6 @@ public class Deepl {
             if(deeplCount > effectiveLimit - billedCharacters - DEEPL_MONTHLY_LIMIT_SAFETY_BUFFER){
                 return text;
             }
-        } else {
-            // Non-DeepL providers do not expose DeepL usage/quota semantics.
-            keyValid = true;
         }
 
 
@@ -158,6 +155,8 @@ public class Deepl {
             @Override
             public void onFailure(Exception error) {
                 if (isDeepLServiceSelected()) {
+                    setKeyValid(false);
+                } else if (isLikelyAuthenticationError(error)) {
                     setKeyValid(false);
                 }
                 translationAttempt.remove(text);
@@ -581,7 +580,7 @@ public class Deepl {
             return deeplCount <= effectiveLimit - DEEPL_MONTHLY_LIMIT_SAFETY_BUFFER;
         }
         if (isLibreTranslateServiceSelected()) {
-            return !getTranslatorUrl().isEmpty();
+            return keyValid && !getTranslatorUrl().isEmpty();
         }
         if (!keyValid) {
             return false;
@@ -618,6 +617,19 @@ public class Deepl {
 
     private boolean isLibreTranslateServiceSelected() {
         return config.getApiServiceConfig() == TranslatingServiceSelectableList.LibreTranslate;
+    }
+
+    private boolean isLikelyAuthenticationError(Exception error) {
+        if (error == null || error.getMessage() == null) {
+            return false;
+        }
+        String message = error.getMessage().toLowerCase(Locale.ROOT);
+        return message.contains("api key")
+                || message.contains("invalid key")
+                || message.contains("unauthorized")
+                || message.contains("forbidden")
+                || message.contains("http 401")
+                || message.contains("http 403");
     }
 
     private int countTextCharacters(String text) {

--- a/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
+++ b/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
@@ -82,6 +82,24 @@ public class Deepl {
         deeplPastTranslationManager = new PastTranslationManager(this, plugin);
     }
 
+    private void apiDebugLog(String message, Object... args) {
+        if (!config.apiDebugLogs()) {
+            return;
+        }
+        log.info("[RuneLingual API] " + message, args);
+    }
+
+    private String previewText(String text) {
+        if (text == null) {
+            return "";
+        }
+        String normalized = text.replace('\n', ' ').replace('\r', ' ').trim();
+        if (normalized.length() <= 100) {
+            return normalized;
+        }
+        return normalized.substring(0, 100) + "...";
+    }
+
     /**
      * Translates the given text from the source language to the target language.
      * Sets deeplCount the number of characters translated using the API
@@ -96,6 +114,8 @@ public class Deepl {
             return text;
         }
         if (isRetryCoolingDown(text)) {
+            apiDebugLog("Skip translate: retry cooldown active (service={}, text='{}')",
+                    config.getApiServiceConfig(), previewText(text));
             return text;
         }
         // if the text is already translated, return the past translation
@@ -123,12 +143,21 @@ public class Deepl {
 
         String url = getTranslatorUrl();
         if(url.isEmpty()){// if selected service is not deepl, return as is
+            apiDebugLog("Skip translate: no API URL configured (service={})", config.getApiServiceConfig());
             return text;
         }
 
         JsonObject urlParameters = getUrlParameters(sourceLang, targetLang, text);
         RequestBody requestBody = FormBody.create(mediaType, urlParameters.toString());
         long requestBodyBytes = getRequestBodyBytes(requestBody);
+        apiDebugLog("Queue request service={} url={} source={} target={} chars={} bodyBytes={} text='{}'",
+                config.getApiServiceConfig(),
+                url,
+                getLanguageCodeForService(sourceLang, true),
+                getLanguageCodeForService(targetLang, false),
+                countTextCharacters(text),
+                requestBodyBytes,
+                previewText(text));
         if (requestBodyBytes > DEEPL_MAX_TOTAL_REQUEST_BYTES) {
             log.warn("Skipping DeepL request: request body too large ({} bytes, max {} bytes).",
                     requestBodyBytes, DEEPL_MAX_TOTAL_REQUEST_BYTES);
@@ -148,6 +177,14 @@ public class Deepl {
                     // add the new translation to the past translations and its file
                     deeplPastTranslationManager.addToPastTranslations(text, translation);
                     setKeyValid(true);
+                    apiDebugLog("Success service={} source='{}' translated='{}'",
+                            config.getApiServiceConfig(),
+                            previewText(text),
+                            previewText(translation));
+                } else {
+                    apiDebugLog("Success but empty translation service={} source='{}'",
+                            config.getApiServiceConfig(),
+                            previewText(text));
                 }
 
             }
@@ -161,6 +198,10 @@ public class Deepl {
                 }
                 translationAttempt.remove(text);
                 scheduleRetryBackoff(text, error);
+                apiDebugLog("Failure service={} source='{}' error={}",
+                        config.getApiServiceConfig(),
+                        previewText(text),
+                        error == null ? "unknown" : previewText(error.getMessage()));
                 handleError(error);
             }
 
@@ -307,6 +348,7 @@ public class Deepl {
         }
 
         if (isDeepLServiceSelected() && (deeplKey == null || deeplKey.isEmpty())) {
+            apiDebugLog("Request blocked: missing API key for DeepL service");
             callback.onFailure(new IOException("API key is missing"));
             return;
         }
@@ -353,6 +395,11 @@ public class Deepl {
                     }
                     if (retryCount < 5) {
                         long delaySeconds = getRetryDelaySeconds();
+                        apiDebugLog("Network failure (service={}) retry={} in {}s error={}",
+                                config.getApiServiceConfig(),
+                                retryCount + 1,
+                                delaySeconds,
+                                previewText(error.getMessage()));
                         scheduler.schedule(() -> {
                             synchronized (apiStateLock) {
                                 if (currentVersion != apiStateVersion || !plugin.getConfig().ApiConfig()) {
@@ -388,6 +435,11 @@ public class Deepl {
                             setGlobalRetryBackoff(System.currentTimeMillis() + RATE_LIMIT_BACKOFF_MILLIS);
                             if (retryCount < 5) {
                                 long delaySeconds = getRetryDelaySeconds();
+                                apiDebugLog("HTTP congestion service={} status={} retry={} in {}s",
+                                        config.getApiServiceConfig(),
+                                        responseCode,
+                                        retryCount + 1,
+                                        delaySeconds);
                                 scheduler.schedule(() -> {
                                     synchronized (apiStateLock) {
                                         if (currentVersion != apiStateVersion || !plugin.getConfig().ApiConfig()) {
@@ -407,6 +459,10 @@ public class Deepl {
                             if (message.length() > 300) {
                                 message = message.substring(0, 300) + "...";
                             }
+                            apiDebugLog("HTTP error service={} status={} body='{}'",
+                                    config.getApiServiceConfig(),
+                                    responseCode,
+                                    previewText(message));
                             callback.onFailure(new IOException("Translation API HTTP " + responseCode + ": " + message));
                             return;
                         }
@@ -491,6 +547,10 @@ public class Deepl {
                         keyValid = true;
                         deeplCount = jsonObject.getInt("character_count");
                         deeplLimit = jsonObject.getInt("character_limit");
+                        apiDebugLog("Usage update service={} count={} limit={}",
+                                config.getApiServiceConfig(),
+                                deeplCount,
+                                deeplLimit);
                         //log.info("Updated deepl count: " + deeplCount + "\nUpdated deepl limit: " + deeplLimit);
                     } else {
                         keyValid = false;

--- a/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
+++ b/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
@@ -487,6 +487,23 @@ public class Deepl {
         return new Random().nextInt(8) + 3;
     }
 
+    public boolean canTranslateNow() {
+        if (!plugin.getConfig().ApiConfig()) {
+            return false;
+        }
+        if (deeplKey == null || deeplKey.isEmpty()) {
+            return false;
+        }
+        if (!keyValid) {
+            return false;
+        }
+        if (System.currentTimeMillis() < globalRetryNotBeforeMillis) {
+            return false;
+        }
+        int effectiveLimit = getEffectiveMonthlyCharacterLimit();
+        return deeplCount <= effectiveLimit - DEEPL_MONTHLY_LIMIT_SAFETY_BUFFER;
+    }
+
     private int getEffectiveMonthlyCharacterLimit() {
         int configuredLimit = deeplLimit > 0 ? deeplLimit : DEEPL_FREE_MONTHLY_CHAR_LIMIT;
         if (Objects.equals(config.getApiServiceConfig().getServiceName(), TranslatingServiceSelectableList.DeepL.getServiceName())) {

--- a/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
+++ b/src/main/java/com/RuneLingual/ApiTranslate/Deepl.java
@@ -491,6 +491,7 @@ public class Deepl {
         if (!plugin.getConfig().ApiConfig()) {
             return false;
         }
+        deeplKey = plugin.getConfig().getAPIKey();
         if (deeplKey == null || deeplKey.isEmpty()) {
             return false;
         }

--- a/src/main/java/com/RuneLingual/ApiTranslate/DeeplUsageOverlay.java
+++ b/src/main/java/com/RuneLingual/ApiTranslate/DeeplUsageOverlay.java
@@ -3,6 +3,7 @@ package com.RuneLingual.ApiTranslate;
 import com.RuneLingual.LangCodeSelectableList;
 import com.RuneLingual.RuneLingualConfig;
 import com.RuneLingual.RuneLingualPlugin;
+import com.RuneLingual.TranslatingServiceSelectableList;
 import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -41,11 +42,33 @@ public class DeeplUsageOverlay  extends Overlay {
         boolean deeplKeyValid = plugin.getDeepl().isKeyValid();
         String deeplCount = Long.toString(plugin.getDeepl().getDeeplCount());
         String deeplLimit = Long.toString(plugin.getDeepl().getDeeplLimit());
+        TranslatingServiceSelectableList selectedService = config.getApiServiceConfig();
 
         Color bgColorCount = new Color(80, 148, 144);
         Color bgColorInvalid = new Color(194, 93, 93);
         panelComponent.getChildren().clear();
         int len;
+        if (selectedService == TranslatingServiceSelectableList.LibreTranslate) {
+            boolean libreAvailable = plugin.getDeepl().canTranslateNow();
+            if (libreAvailable) {
+                panelComponent.setBackgroundColor(bgColorCount);
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left("LibreTranslate:")
+                        .right("usage N/A")
+                        .build());
+                len = ("LibreTranslate: usage N/A".length() + 2) * enCharSize;
+            } else {
+                String errorMessage = "LibreTranslate unavailable.\nCheck URL/API key.";
+                panelComponent.setBackgroundColor(bgColorInvalid);
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left(errorMessage)
+                        .build());
+                len = (getMaxLetters(errorMessage.split("\n")) + 2) * foreignCharSize;
+            }
+            panelComponent.setPreferredSize(new Dimension(len,0));
+            return panelComponent.render(graphics);
+        }
+
         if (deeplKeyValid) {
             panelComponent.setBackgroundColor(bgColorCount);
             panelComponent.getChildren().add(LineComponent.builder()

--- a/src/main/java/com/RuneLingual/ApiTranslate/DeeplUsageOverlay.java
+++ b/src/main/java/com/RuneLingual/ApiTranslate/DeeplUsageOverlay.java
@@ -12,6 +12,7 @@ import net.runelite.client.ui.overlay.components.PanelComponent;
 
 import javax.inject.Inject;
 import java.awt.*;
+import java.text.NumberFormat;
 
 
 public class DeeplUsageOverlay  extends Overlay {
@@ -51,12 +52,21 @@ public class DeeplUsageOverlay  extends Overlay {
         if (selectedService == TranslatingServiceSelectableList.LibreTranslate) {
             boolean libreAvailable = plugin.getDeepl().canTranslateNow();
             if (libreAvailable) {
+                NumberFormat nf = NumberFormat.getIntegerInstance();
+                String chars = nf.format(plugin.getDeepl().getLibreTranslateCharCount());
+                String reqs = nf.format(plugin.getDeepl().getLibreTranslateRequestCount());
                 panelComponent.setBackgroundColor(bgColorCount);
                 panelComponent.getChildren().add(LineComponent.builder()
                         .left("LibreTranslate:")
-                        .right("usage N/A")
+                        .right(chars + " chars")
                         .build());
-                len = ("LibreTranslate: usage N/A".length() + 2) * enCharSize;
+                panelComponent.getChildren().add(LineComponent.builder()
+                        .left("Requests:")
+                        .right(reqs)
+                        .build());
+                int line1 = ("LibreTranslate: " + chars + " chars").length() + 2;
+                int line2 = ("Requests: " + reqs).length() + 2;
+                len = Math.max(line1, line2) * enCharSize;
             } else {
                 String errorMessage = "LibreTranslate unavailable.\nCheck URL/API key.";
                 panelComponent.setBackgroundColor(bgColorInvalid);

--- a/src/main/java/com/RuneLingual/ChatMessages/ChatCapture.java
+++ b/src/main/java/com/RuneLingual/ChatMessages/ChatCapture.java
@@ -210,6 +210,13 @@ public class ChatCapture
     }
 
     private void chatTransformer(String message, MessageNode node, ChatMessage chatMessage) {
+        String originalOutgoing = plugin.consumeOutgoingOriginalMessage(chatMessage);
+        if (originalOutgoing != null) {
+            replaceChatMessage(originalOutgoing, node);
+            addMsgToSidePanel(chatMessage, originalOutgoing);
+            return;
+        }
+
         String newMessage = plugin.getChatInputRLingual().transformChatText(message);
         Transformer transformer = new Transformer(plugin);
         Colors textColor = chatColorManager.getMessageColor();
@@ -343,6 +350,8 @@ public class ChatCapture
         switch (chatConfig) {
             case TRANSFORM:
                 return TransformOption.TRANSFORM;
+            case USE_API:
+                return TransformOption.TRANSLATE_API;
             case LEAVE_AS_IS:
                 return TransformOption.AS_IS;
             default:

--- a/src/main/java/com/RuneLingual/ChatMessages/ChatCapture.java
+++ b/src/main/java/com/RuneLingual/ChatMessages/ChatCapture.java
@@ -190,7 +190,8 @@ public class ChatCapture
     
     private void onlineTranslator(String message, MessageNode node, ChatMessage chatMessage)
     {
-        if(plugin.getDeepl().getDeeplCount() + message.length() + 1000 > plugin.getDeepl().getDeeplLimit()) {
+        if(plugin.getDeepl().usesDeepLUsageLimits()
+                && plugin.getDeepl().getDeeplCount() + message.length() + 1000 > plugin.getDeepl().getDeeplLimit()) {
             //log.info("DeepL limit reached, cannot translate message.");
             return;
         }

--- a/src/main/java/com/RuneLingual/ChatMessages/OverheadCapture.java
+++ b/src/main/java/com/RuneLingual/ChatMessages/OverheadCapture.java
@@ -139,6 +139,8 @@ public class OverheadCapture {
                 return TransformOption.AS_IS;
             case TRANSFORM:
                 return TransformOption.TRANSFORM;
+            case USE_API:
+                return TransformOption.TRANSLATE_API;
             default:
                 return TransformOption.AS_IS;
         }

--- a/src/main/java/com/RuneLingual/ChatMessages/PlayerMessage.java
+++ b/src/main/java/com/RuneLingual/ChatMessages/PlayerMessage.java
@@ -393,6 +393,9 @@ public class PlayerMessage {
         if(config == RuneLingualConfig.chatSelfConfig.LEAVE_AS_IS){
             return Transformer.TransformOption.AS_IS;
         }
+        if(config == RuneLingualConfig.chatSelfConfig.USE_API){
+            return Transformer.TransformOption.TRANSLATE_API;
+        }
         if(config == RuneLingualConfig.chatSelfConfig.TRANSFORM){
             return Transformer.TransformOption.TRANSFORM;
         }

--- a/src/main/java/com/RuneLingual/LangCodeSelectableList.java
+++ b/src/main/java/com/RuneLingual/LangCodeSelectableList.java
@@ -10,7 +10,9 @@ import javax.inject.Inject;
 public enum LangCodeSelectableList
 {
     ENGLISH ("en", "EN","EN", 8, 14, 6, 6, false, false, false, false, true, false, false),
-    PORTUGUÊS_BRASILEIRO ("pt_br", "PT","PT-BR", 8, 11, 6, 6, false, false, false, false, true, false, true),
+    // PT-BR uses the same Latin font metrics as EN/PT-PT in the client.
+    // A too-small charHeight makes multi-line tooltips (Prayer/Spellbook) overlap and look "blank"/garbled.
+    PORTUGUÊS_BRASILEIRO ("pt_br", "PT","PT-BR", 8, 14, 6, 6, false, false, false, false, true, false, true),
     NORSK("no", "NB", "NB", 8, 14, 6, 6, false, false, false, false, true, false, true),
     日本語("ja", "JA", "JA", 12, 12, 12, 15, true, false, true, true, false, true, true),
     Русский("ru", "RU", "RU", 8, 12, 6, 6, true, false, true, false, true, false, true),

--- a/src/main/java/com/RuneLingual/RuneLingualConfig.java
+++ b/src/main/java/com/RuneLingual/RuneLingualConfig.java
@@ -151,6 +151,17 @@ public interface RuneLingualConfig extends Config {
     }
 
     @ConfigItem(
+            name = "API Debug Logs",
+            description = "Logs API request/result details in client.log for troubleshooting",
+            section = SECTION_CHAT_SETTINGS,
+            keyName = "apiDebugLogs",
+            position = 6 + offset
+    )
+    default boolean apiDebugLogs() {
+        return false;
+    }
+
+    @ConfigItem(
             name = "Enable Word Count Overlay",
             description = "whether to show how many characters you have used",
             section = SECTION_CHAT_SETTINGS,

--- a/src/main/java/com/RuneLingual/RuneLingualConfig.java
+++ b/src/main/java/com/RuneLingual/RuneLingualConfig.java
@@ -140,6 +140,17 @@ public interface RuneLingualConfig extends Config {
     }
 
     @ConfigItem(
+            name = "LibreTranslate URL",
+            description = "Base URL for LibreTranslate (self-host or public instance), ex: https://libretranslate.com",
+            section = SECTION_CHAT_SETTINGS,
+            keyName = "libreTranslateUrl",
+            position = 5 + offset
+    )
+    default String getLibreTranslateUrl() {
+        return "https://libretranslate.com";
+    }
+
+    @ConfigItem(
             name = "Enable Word Count Overlay",
             description = "whether to show how many characters you have used",
             section = SECTION_CHAT_SETTINGS,

--- a/src/main/java/com/RuneLingual/RuneLingualConfig.java
+++ b/src/main/java/com/RuneLingual/RuneLingualConfig.java
@@ -94,6 +94,17 @@ public interface RuneLingualConfig extends Config {
     } // getHelpLink shouldnt be used anywhere, instead use helpLink
 
     @ConfigItem(
+            name = "Build marker",
+            description = "Confirms this patched dev build is loaded",
+            position = 2 + offset_section1,
+            keyName = "devBuildMarkerBasic",
+            section = SECTION_BASIC_SETTINGS
+    )
+    default String devBuildMarkerBasic() {
+        return "DEV PATCH ACTIVE: local chat keeps original outgoing text";
+    }
+
+    @ConfigItem(
             name = "Enable Online Translation",
             description = "whether to translate using online services",
             section = SECTION_CHAT_SETTINGS,
@@ -238,6 +249,28 @@ public interface RuneLingualConfig extends Config {
     }
 
     @ConfigItem(
+            name = "Books/Scrolls via API",
+            description = "When 'Interfaces' is set to 'USE_API', also translate books, scrolls and journals with API.",
+            position = 10 + offset_section2,
+            keyName = "apiBooksAndScrolls",
+            section = SECTION_GAME_SYSTEM_TEXT
+    )
+    default boolean apiBooksAndScrolls() {
+        return true;
+    }
+
+    @ConfigItem(
+            name = "Lobby/Login via API",
+            description = "When 'Interfaces' is set to 'USE_API', also translate lobby/login page text widgets with API.",
+            position = 11 + offset_section2,
+            keyName = "apiLobbyScreen",
+            section = SECTION_GAME_SYSTEM_TEXT
+    )
+    default boolean apiLobbyScreen() {
+        return true;
+    }
+
+    @ConfigItem(
             name = "Public",
             description = "Option for public chat messages",
             position = 3 + offset_section3,
@@ -347,6 +380,17 @@ public interface RuneLingualConfig extends Config {
         return chatSelfConfig.TRANSFORM;
     }
 
+    @ConfigItem(
+            name = "Show original outgoing locally",
+            description = "When transforming your own outgoing messages, keep your local chat history showing the original text.",
+            position = 6 + offset_section4,
+            keyName = "showOriginalOutgoing",
+            section = SECTION_MY_CHAT_MESSAGES
+    )
+    default boolean showOriginalOutgoing() {
+        return true;
+    }
+
     String defaultText4ForcefulPlayerSettings = "enter player names here, separated by commas or new line";
 
     @ConfigItem(
@@ -381,10 +425,21 @@ public interface RuneLingualConfig extends Config {
     }
 
     @ConfigItem(
+            name = "Build marker (dev)",
+            description = "Marker to confirm this is the patched build with outgoing chat local-original fix",
+            keyName = "devBuildMarker",
+            position = 1 + offset_section6,
+            section = SECTION_DEBUGGING
+    )
+    default String devBuildMarker() {
+        return "DEV PATCH: outgoing transform keeps local original (2026-02-16)";
+    }
+
+    @ConfigItem(
             name = "Local file location",
             description = "Location of the files used for translation and logs. Right click this text then choose 'reset' to get default location",
             keyName = "fileLocation",
-            position = 1 + offset_section6,
+            position = 2 + offset_section6,
             secret = true,
             section = SECTION_DEBUGGING
     )
@@ -396,7 +451,7 @@ public interface RuneLingualConfig extends Config {
             name = "Use Custom Data",
             description = "Use custom data for translations on github repository",
             keyName = "useCustomData",
-            position = 2 + offset_section6,
+            position = 3 + offset_section6,
             section = SECTION_DEBUGGING
     )
     default boolean useCustomData() {
@@ -407,7 +462,7 @@ public interface RuneLingualConfig extends Config {
             name = "Use Custom Data URL",
             description = "Change the user name part and public to draft if necessary. Do not include the language code. Right click 'reset' to get default url",
             keyName = "customDataUrl",
-            position = 3 + offset_section6,
+            position = 4 + offset_section6,
             section = SECTION_DEBUGGING
     )
     default String getCustomDataUrl() {
@@ -418,7 +473,7 @@ public interface RuneLingualConfig extends Config {
             name = "Enable logging (Widgets)",
             description = "Output untranslated game messages to a file, which will be found in '<the local file location defined above>/logs'.",
             keyName = "enableLogging",
-            position = 4 + offset_section6,
+            position = 5 + offset_section6,
             section = SECTION_DEBUGGING
     )
     default boolean enableLoggingWidget() {
@@ -429,7 +484,7 @@ public interface RuneLingualConfig extends Config {
             name = "Enable logging (Game Messages)",
             description = "Output untranslated game messages to a file, which will be found in '<the local file location defined above>/logs'.",
             keyName = "enableLoggingSql",
-            position = 5 + offset_section6,
+            position = 6 + offset_section6,
             section = SECTION_DEBUGGING
     )
     default boolean enableLoggingGameMessage() {
@@ -440,7 +495,7 @@ public interface RuneLingualConfig extends Config {
             name = "Enable logging (Any)",
             description = "Output untranslated game messages to a file, which will be found in '<the local file location defined above>/logs'.",
             keyName = "enableLoggingChat",
-            position = 6 + offset_section6,
+            position = 7 + offset_section6,
             section = SECTION_DEBUGGING
     )
     default boolean enableLoggingAny() {
@@ -463,6 +518,7 @@ public interface RuneLingualConfig extends Config {
 
     enum chatSelfConfig {
         TRANSFORM,
+        USE_API,
         LEAVE_AS_IS,
     }
 

--- a/src/main/java/com/RuneLingual/RuneLingualPlugin.java
+++ b/src/main/java/com/RuneLingual/RuneLingualPlugin.java
@@ -10,6 +10,7 @@ import com.RuneLingual.Widgets.PartialTranslationManager;
 import com.RuneLingual.Widgets.Widget2ModDict;
 import com.RuneLingual.Widgets.WidgetCapture;
 import com.RuneLingual.Widgets.WidgetsUtilRLingual;
+import com.RuneLingual.commonFunctions.Colors;
 import com.RuneLingual.commonFunctions.FileNameAndPath;
 import com.RuneLingual.debug.OutputToFile;
 import com.RuneLingual.nonLatin.*;
@@ -28,7 +29,7 @@ import net.runelite.api.events.*;
 import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.WidgetUtil;
 import net.runelite.client.config.ConfigManager;
-import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -52,23 +53,57 @@ import okhttp3.OkHttpClient;
 import java.awt.image.BufferedImage;
 import java.sql.Connection;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Slf4j
 @PluginDescriptor(
         // Plugin name shown at plugin hub
-        name = "RuneLingual",
-        description = "All-in-one translation plugin for OSRS."
+        name = "RuneLingual Dev",
+        description = "All-in-one translation plugin for OSRS.",
+        loadInSafeMode = true
 )
 
 public class RuneLingualPlugin extends Plugin {
+    private static final String CHATBOX_INPUT_EVENT = "chatboxInput";
+    private static final int CHATBOX_TYPE_PUBLIC = 0;
+    private static final int CHATBOX_TYPE_CHEAT = 1;
+    private static final int CHATBOX_TYPE_FRIENDS = 2;
+    private static final int CHATBOX_TYPE_CLAN = 3;
+    private static final int CHATBOX_TYPE_GUEST_CLAN = 4;
+    private static final int CHATBOX_TYPE_GIM = 5;
+    private static final int OUTGOING_TRANSFORM_MIN_LENGTH = 2;
+    private static final long OUTGOING_TRANSLATION_TIMEOUT_MILLIS = 5000L;
+    private static final long OUTGOING_RESTORE_TIMEOUT_MILLIS = 15000L;
+
+    private static final class OutgoingRestoreMessage {
+        private final ChatMessageType expectedType;
+        private final String sentMessage;
+        private final String originalMessage;
+        private final long expiresAt;
+
+        private OutgoingRestoreMessage(ChatMessageType expectedType, String sentMessage, String originalMessage, long expiresAt) {
+            this.expectedType = expectedType;
+            this.sentMessage = sentMessage;
+            this.originalMessage = originalMessage;
+            this.expiresAt = expiresAt;
+        }
+    }
+
     @Inject
     @Getter
     private Client client;
     @Inject
     private ClientThread clientThread;
+    @Inject
+    private EventBus eventBus;
     @Inject
     private OverlayManager overlayManager;
     @Inject
@@ -185,9 +220,21 @@ public class RuneLingualPlugin extends Plugin {
 
     // stores selected languages during this session, to prevent re-initializing char images
     private final Set<LangCodeSelectableList> pastLanguages = new HashSet<>();
+    private final Deque<OutgoingRestoreMessage> outgoingMessagesToRestore = new ConcurrentLinkedDeque<>();
+    private final ArrayList<EventBus.Subscriber> manualSubscriptions = new ArrayList<>();
+    private ExecutorService outgoingTranslationExecutor;
+    private boolean suppressOutgoingScriptCallback;
 
     @Override
     protected void startUp() throws Exception {
+        if (outgoingTranslationExecutor == null || outgoingTranslationExecutor.isShutdown()) {
+            outgoingTranslationExecutor = Executors.newSingleThreadExecutor(r -> {
+                Thread thread = new Thread(r, "runelingual-outgoing-translate");
+                thread.setDaemon(true);
+                return thread;
+            });
+        }
+
         //get selected language
         targetLanguage = config.getSelectedLanguage();
         pastLanguages.add(targetLanguage);
@@ -211,18 +258,21 @@ public class RuneLingualPlugin extends Plugin {
 
         // side panel
         startPanel();
+        registerEventSubscriptions();
         //log.info("RuneLingual started!");
     }
 
-    @Subscribe
-    public void onOverheadTextChanged(OverheadTextChanged event) throws Exception {
+    public void onOverheadTextChanged(OverheadTextChanged event) {
         if (targetLanguage == LangCodeSelectableList.ENGLISH) {
             return;
         }
-        overheadCapture.translateOverhead(event);
+        try {
+            overheadCapture.translateOverhead(event);
+        } catch (Exception e) {
+            log.debug("Failed to translate overhead text.", e);
+        }
     }
 
-    @Subscribe
     public void onWidgetLoaded(WidgetLoaded event) {
         if (targetLanguage == LangCodeSelectableList.ENGLISH) {
             return;
@@ -233,7 +283,6 @@ public class RuneLingualPlugin extends Plugin {
 //		});
     }
 
-    @Subscribe
     private void onBeforeRender(BeforeRender event) {
         if (targetLanguage == LangCodeSelectableList.ENGLISH) {
             return;
@@ -243,7 +292,6 @@ public class RuneLingualPlugin extends Plugin {
         widgetCapture.translateWidget();
     }
 
-    @Subscribe
     public void onMenuOpened(MenuOpened event) {
         if (targetLanguage == LangCodeSelectableList.ENGLISH) {
             return;
@@ -252,22 +300,52 @@ public class RuneLingualPlugin extends Plugin {
         menuCapture.handleOpenedMenu(event);
     }
 
+    public void onScriptCallbackEvent(ScriptCallbackEvent event) {
+        if (targetLanguage == LangCodeSelectableList.ENGLISH
+                || client.getGameState() != GameState.LOGGED_IN
+                || !CHATBOX_INPUT_EVENT.equals(event.getEventName())) {
+            return;
+        }
+        if (suppressOutgoingScriptCallback) {
+            return;
+        }
 
+        Object[] objectStack = client.getObjectStack();
+        int[] intStack = client.getIntStack();
+        int objectStackSize = client.getObjectStackSize();
+        int intStackSize = client.getIntStackSize();
 
+        if (objectStackSize < 1 || intStackSize < 2 || !(objectStack[objectStackSize - 1] instanceof String)) {
+            return;
+        }
 
-    @Subscribe
-    public void onChatMessage(ChatMessage event) throws Exception {
+        String originalText = (String) objectStack[objectStackSize - 1];
+        int chatType = intStack[intStackSize - 2];
+        int clanTarget = intStack[intStackSize - 1];
+
+        if (!shouldTransformOutgoingMessage(originalText, chatType)) {
+            return;
+        }
+
+        // Prevent the default sender from sending the original text.
+        objectStack[objectStackSize - 1] = "";
+        translateAndSendOutgoingMessage(originalText, chatType, clanTarget);
+    }
+    public void onChatMessage(ChatMessage event) {
         if (targetLanguage == LangCodeSelectableList.ENGLISH) {
             return;
         }
         if (client.getGameState() != GameState.LOGGED_IN && client.getGameState() != GameState.HOPPING) {
             return;
         }
-        chatCapture.handleChatMessage(event);
+        try {
+            chatCapture.handleChatMessage(event);
+        } catch (Exception e) {
+            log.debug("Failed handling chat message event.", e);
+        }
     }
 
 
-    @Subscribe
     public void onGameStateChanged(GameStateChanged gameStateChanged) {
         if (targetLanguage == LangCodeSelectableList.ENGLISH) {
             return;
@@ -278,11 +356,11 @@ public class RuneLingualPlugin extends Plugin {
         }
     }
 
-    @Subscribe
     public void onConfigChanged(ConfigChanged event) {
         if (!event.getGroup().equals(RuneLingualConfig.GROUP)) {
             return;
         }
+        outgoingMessagesToRestore.clear();
         // if language is changed
         if (targetLanguage != config.getSelectedLanguage()) {
             targetLanguage = config.getSelectedLanguage();
@@ -326,14 +404,12 @@ public class RuneLingualPlugin extends Plugin {
 
     }
 
-    @Subscribe
     public void onNpcDespawned(NpcDespawned npcDespawned) {
         if (npcDespawned.getNpc() == interactedNpc) {
             interactedNpc = null;
         }
     }
 
-    @Subscribe
     public void onGameTick(GameTick gameTick) {
         if (client.getTickCount() > clickTick && client.getLocalDestinationLocation() == null) {
             // when the destination is reached, clear the interacting object
@@ -349,7 +425,6 @@ public class RuneLingualPlugin extends Plugin {
         overheadCapture.handlePendingOverheadTranslations();
     }
 
-    @Subscribe
     public void onInteractingChanged(InteractingChanged interactingChanged) {
         if (interactingChanged.getSource() == client.getLocalPlayer()
                 && client.getTickCount() > clickTick && interactingChanged.getTarget() != interactedNpc) {
@@ -358,7 +433,6 @@ public class RuneLingualPlugin extends Plugin {
         }
     }
 
-    @Subscribe
     public void onMenuOptionClicked(MenuOptionClicked menuOptionClicked) {
         switch (menuOptionClicked.getMenuAction()) {
             case WIDGET_TARGET_ON_GAME_OBJECT:
@@ -413,6 +487,184 @@ public class RuneLingualPlugin extends Plugin {
         }
     }
 
+    private void registerEventSubscriptions() {
+        unregisterEventSubscriptions();
+        manualSubscriptions.add(eventBus.register(OverheadTextChanged.class, this::onOverheadTextChanged, 0f));
+        manualSubscriptions.add(eventBus.register(WidgetLoaded.class, this::onWidgetLoaded, 0f));
+        manualSubscriptions.add(eventBus.register(BeforeRender.class, this::onBeforeRender, 0f));
+        manualSubscriptions.add(eventBus.register(MenuOpened.class, this::onMenuOpened, 0f));
+        manualSubscriptions.add(eventBus.register(ScriptCallbackEvent.class, this::onScriptCallbackEvent, 100f));
+        manualSubscriptions.add(eventBus.register(ChatMessage.class, this::onChatMessage, 0f));
+        manualSubscriptions.add(eventBus.register(GameStateChanged.class, this::onGameStateChanged, 0f));
+        manualSubscriptions.add(eventBus.register(ConfigChanged.class, this::onConfigChanged, 0f));
+        manualSubscriptions.add(eventBus.register(NpcDespawned.class, this::onNpcDespawned, 0f));
+        manualSubscriptions.add(eventBus.register(GameTick.class, this::onGameTick, 0f));
+        manualSubscriptions.add(eventBus.register(InteractingChanged.class, this::onInteractingChanged, 0f));
+        manualSubscriptions.add(eventBus.register(MenuOptionClicked.class, this::onMenuOptionClicked, 0f));
+    }
+
+    private void unregisterEventSubscriptions() {
+        for (EventBus.Subscriber subscriber : manualSubscriptions) {
+            eventBus.unregister(subscriber);
+        }
+        manualSubscriptions.clear();
+    }
+
+    @Nullable
+    public String consumeOutgoingOriginalMessage(ChatMessage chatMessage) {
+        if (!config.showOriginalOutgoing() || !isOwnMessage(chatMessage)) {
+            return null;
+        }
+
+        long now = System.currentTimeMillis();
+        cleanupExpiredOutgoingMessages(now);
+
+        OutgoingRestoreMessage matched = null;
+        for (OutgoingRestoreMessage message : outgoingMessagesToRestore) {
+            if (message.expiresAt < now) {
+                continue;
+            }
+
+            if (message.expectedType == chatMessage.getType() && Objects.equals(message.sentMessage, chatMessage.getMessage())) {
+                matched = message;
+                break;
+            }
+        }
+
+        if (matched == null) {
+            return null;
+        }
+
+        outgoingMessagesToRestore.remove(matched);
+        return matched.originalMessage;
+    }
+
+    private void translateAndSendOutgoingMessage(String originalText, int chatType, int clanTarget) {
+        if (outgoingTranslationExecutor == null || outgoingTranslationExecutor.isShutdown()) {
+            clientThread.invoke(() -> sendTranslatedChat(originalText, originalText, chatType, clanTarget));
+            return;
+        }
+
+        CompletableFuture
+                .supplyAsync(() -> translateOutgoingMessage(originalText), outgoingTranslationExecutor)
+                .exceptionally(ex -> {
+                    log.debug("Failed to translate outgoing chat message, sending original text.", ex);
+                    return originalText;
+                })
+                .thenAccept(translatedText ->
+                        clientThread.invoke(() -> sendTranslatedChat(originalText, translatedText, chatType, clanTarget)));
+    }
+
+    private String translateOutgoingMessage(String originalText) {
+        if (!config.ApiConfig()) {
+            return originalText;
+        }
+        return deepl.translateBlocking(
+                originalText,
+                config.getSelectedLanguage(),
+                LangCodeSelectableList.ENGLISH,
+                OUTGOING_TRANSLATION_TIMEOUT_MILLIS
+        );
+    }
+
+    private void sendTranslatedChat(String originalMessage, String translatedMessage, int chatType, int clanTarget) {
+        String messageToSend = translatedMessage;
+        if (messageToSend == null || messageToSend.isBlank()) {
+            messageToSend = originalMessage;
+        }
+
+        ChatMessageType expectedType = getExpectedOutgoingType(chatType);
+        if (config.showOriginalOutgoing()
+                && expectedType != null
+                && !Objects.equals(messageToSend, originalMessage)) {
+            outgoingMessagesToRestore.addLast(
+                    new OutgoingRestoreMessage(
+                            expectedType,
+                            messageToSend,
+                            originalMessage,
+                            System.currentTimeMillis() + OUTGOING_RESTORE_TIMEOUT_MILLIS
+                    )
+            );
+            cleanupExpiredOutgoingMessages(System.currentTimeMillis());
+        }
+
+        suppressOutgoingScriptCallback = true;
+        try {
+            client.runScript(ScriptID.CHAT_SEND, messageToSend, chatType, clanTarget, 0, -1);
+        } finally {
+            suppressOutgoingScriptCallback = false;
+        }
+    }
+
+    private boolean shouldTransformOutgoingMessage(String originalText, int chatType) {
+        if (originalText == null || originalText.trim().length() < OUTGOING_TRANSFORM_MIN_LENGTH) {
+            return false;
+        }
+        if (!config.ApiConfig()) {
+            return false;
+        }
+        if (chatType == CHATBOX_TYPE_CHEAT) {
+            return false;
+        }
+        RuneLingualConfig.chatSelfConfig outgoingMode = getMyOutgoingConfig(chatType);
+        return outgoingMode == RuneLingualConfig.chatSelfConfig.TRANSFORM
+                || outgoingMode == RuneLingualConfig.chatSelfConfig.USE_API;
+    }
+
+    private RuneLingualConfig.chatSelfConfig getMyOutgoingConfig(int chatType) {
+        switch (chatType) {
+            case CHATBOX_TYPE_PUBLIC:
+                return config.getMyPublicConfig();
+            case CHATBOX_TYPE_FRIENDS:
+                return config.getMyFcConfig();
+            case CHATBOX_TYPE_CLAN:
+                return config.getMyClanConfig();
+            case CHATBOX_TYPE_GUEST_CLAN:
+                return config.getMyGuestClanConfig();
+            case CHATBOX_TYPE_GIM:
+                return config.getMyGIMConfig();
+            default:
+                return RuneLingualConfig.chatSelfConfig.LEAVE_AS_IS;
+        }
+    }
+
+    private ChatMessageType getExpectedOutgoingType(int chatType) {
+        switch (chatType) {
+            case CHATBOX_TYPE_PUBLIC:
+                return ChatMessageType.PUBLICCHAT;
+            case CHATBOX_TYPE_FRIENDS:
+                return ChatMessageType.FRIENDSCHAT;
+            case CHATBOX_TYPE_CLAN:
+                return ChatMessageType.CLAN_CHAT;
+            case CHATBOX_TYPE_GUEST_CLAN:
+                return ChatMessageType.CLAN_GUEST_CHAT;
+            case CHATBOX_TYPE_GIM:
+                return ChatMessageType.CLAN_GIM_CHAT;
+            default:
+                return null;
+        }
+    }
+
+    private void cleanupExpiredOutgoingMessages(long now) {
+        while (true) {
+            OutgoingRestoreMessage head = outgoingMessagesToRestore.peekFirst();
+            if (head == null || head.expiresAt >= now) {
+                return;
+            }
+            outgoingMessagesToRestore.pollFirst();
+        }
+    }
+
+    private boolean isOwnMessage(ChatMessage chatMessage) {
+        Player localPlayer = client.getLocalPlayer();
+        if (localPlayer == null || localPlayer.getName() == null || chatMessage.getName() == null) {
+            return false;
+        }
+        String localPlayerName = Colors.removeAllTags(localPlayer.getName());
+        String senderName = Colors.removeAllTags(chatMessage.getName());
+        return Objects.equals(localPlayerName, senderName);
+    }
+
     private void queueUpdateAllOverrides()
     {
         clientThread.invoke(() -> {
@@ -432,6 +684,13 @@ public class RuneLingualPlugin extends Plugin {
 
     @Override
     protected void shutDown() throws Exception {
+        unregisterEventSubscriptions();
+        if (outgoingTranslationExecutor != null) {
+            outgoingTranslationExecutor.shutdownNow();
+            outgoingTranslationExecutor = null;
+        }
+        outgoingMessagesToRestore.clear();
+
         clientToolBar.removeNavigation(navButton);
         overlayManager.remove(mouseTooltipOverlay);
         overlayManager.remove(deeplUsageOverlay);
@@ -514,4 +773,3 @@ public class RuneLingualPlugin extends Plugin {
     }
 
 }
-

--- a/src/main/java/com/RuneLingual/TranslatingServiceSelectableList.java
+++ b/src/main/java/com/RuneLingual/TranslatingServiceSelectableList.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 public enum TranslatingServiceSelectableList
 {
     DeepL ("deepl"),
-    DeepL_PRO ("deepl_pro"),;
+    DeepL_PRO ("deepl_pro"),
+    LibreTranslate ("libretranslate");
 //    GOOGLE_TRANSLATE ("google"),
 //    OPENAI_GPT ("openai");
 
@@ -15,4 +16,8 @@ public enum TranslatingServiceSelectableList
     TranslatingServiceSelectableList(String code){this.serviceName = code;}
 
     public String getService(){return this.serviceName;}
+
+    public boolean isDeepLFamily() {
+        return this == DeepL || this == DeepL_PRO;
+    }
 }

--- a/src/main/java/com/RuneLingual/Widgets/WidgetCapture.java
+++ b/src/main/java/com/RuneLingual/Widgets/WidgetCapture.java
@@ -284,6 +284,13 @@ public class WidgetCapture {
     private void translateWidgetApi(Widget widget) {
         String text = widget.getText();
         Colors color = Colors.getColorArray(widget.getText(), Colors.getColorFromHex(Colors.IntToHex(widget.getTextColor())))[0];
+
+        // Tooltips can be bottom-aligned by default; once we resize them to fit translated text,
+        // the content can appear to "drop" down or get clipped. Force top alignment for stability.
+        if (widget.getId() == ids.getPrayerTabHoverTextId() || widget.getId() == ids.getSpellbookTabHoverTextId()) {
+            widget.setYTextAlignment(WidgetTextAlignment.TOP);
+        }
+
         widgetsUtilRLingual.setWidgetText_ApiTranslation(widget, text, color);
         widgetsUtilRLingual.changeLineHeight(widget);
         widgetsUtilRLingual.changeWidgetSize_ifNeeded(widget);

--- a/src/main/java/com/RuneLingual/Widgets/WidgetCapture.java
+++ b/src/main/java/com/RuneLingual/Widgets/WidgetCapture.java
@@ -191,8 +191,9 @@ public class WidgetCapture {
             return;
         }
 
-        boolean interfaceApiMode = plugin.getConfig().getInterfaceTextConfig() == RuneLingualConfig.ingameTranslationConfig.USE_API
+        boolean interfaceApiConfigured = plugin.getConfig().getInterfaceTextConfig() == RuneLingualConfig.ingameTranslationConfig.USE_API
                 && plugin.getConfig().ApiConfig();
+        boolean interfaceApiAvailable = interfaceApiConfigured && plugin.getDeepl().canTranslateNow();
         boolean booksAndScrollsApiEnabled = plugin.getConfig().apiBooksAndScrolls();
         boolean isApiBookOrScrollWidget = booksAndScrollsApiEnabled
                 && (API_BOOK_SCROLL_INTERFACE_IDS.contains(widgetGroup)
@@ -200,18 +201,20 @@ public class WidgetCapture {
 
         // Book/scroll widgets do not always use WidgetType.TEXT + valid font ids.
         // Handle them with a dedicated API path based on "has translatable text".
-        if (interfaceApiMode && isApiBookOrScrollWidget) {
+        if (interfaceApiAvailable && isApiBookOrScrollWidget) {
             translateWidgetApiBookOrScroll(widget);
             return;
         }
 
-        if (interfaceApiMode && shouldApiTranslateLobbyWidget(widget)) {
+        if (interfaceApiAvailable && shouldApiTranslateLobbyWidget(widget)) {
             translateWidgetApiLobby(widget);
             return;
         }
 
         if(shouldTranslateWidget(widget)) {
-            if (interfaceApiMode) {
+            // If API mode is configured but temporarily unavailable (key/limit/congestion),
+            // keep translating with local resources instead of skipping interface text.
+            if (interfaceApiAvailable) {
                 return;
             }
 

--- a/src/main/java/com/RuneLingual/Widgets/WidgetCapture.java
+++ b/src/main/java/com/RuneLingual/Widgets/WidgetCapture.java
@@ -61,6 +61,7 @@ public class WidgetCapture {
             Questlist.UNIVERSE,
             Scroll.UNIVERSE,
             IiScroll.UNIVERSE,
+            Prayerbook.UNIVERSE,
             MagicSpellbook.UNIVERSE,
             Longscroll.UNIVERSE,
             Eventscroll.UNIVERSE,

--- a/src/main/java/com/RuneLingual/Widgets/WidgetCapture.java
+++ b/src/main/java/com/RuneLingual/Widgets/WidgetCapture.java
@@ -47,6 +47,7 @@ public class WidgetCapture {
             QuestscrollSpeedrun.UNIVERSE,
             Scroll.UNIVERSE,
             IiScroll.UNIVERSE,
+            MagicSpellbook.UNIVERSE,
             Longscroll.UNIVERSE,
             Eventscroll.UNIVERSE,
             HorrorPrayerbooks.UNIVERSE,

--- a/src/main/java/com/RuneLingual/Widgets/WidgetCapture.java
+++ b/src/main/java/com/RuneLingual/Widgets/WidgetCapture.java
@@ -38,13 +38,27 @@ public class WidgetCapture {
         return WidgetUtil.componentToInterface(componentId);
     }
 
-    private static final Set<Integer> API_BOOK_SCROLL_INTERFACE_IDS = Set.of(
+    private static int normalizeInterfaceOrComponentId(int id) {
+        return id > 0xFFFF ? WidgetUtil.componentToInterface(id) : id;
+    }
+
+    private static Set<Integer> normalizeInterfaceIds(Set<Integer> rawIds) {
+        Set<Integer> normalized = new HashSet<>();
+        for (int rawId : rawIds) {
+            normalized.add(normalizeInterfaceOrComponentId(rawId));
+        }
+        return Collections.unmodifiableSet(normalized);
+    }
+
+    private static final Set<Integer> API_BOOK_SCROLL_INTERFACE_IDS = normalizeInterfaceIds(Set.of(
             Book.UNIVERSE,
             IndexedBook.UNIVERSE,
             Bookofscrolls.UNIVERSE,
             Journalscroll.UNIVERSE,
             Questscroll.UNIVERSE,
             QuestscrollSpeedrun.UNIVERSE,
+            Questdisplay.UNIVERSE,
+            Questlist.UNIVERSE,
             Scroll.UNIVERSE,
             IiScroll.UNIVERSE,
             MagicSpellbook.UNIVERSE,
@@ -104,7 +118,7 @@ public class WidgetCapture {
             KillLog.UNIVERSE,
             FairyringsLog.UNIVERSE,
             SailingLog.UNIVERSE
-    );
+    ));
 
     @Inject
     private RuneLingualPlugin plugin;

--- a/src/main/java/com/RuneLingual/Widgets/WidgetCapture.java
+++ b/src/main/java/com/RuneLingual/Widgets/WidgetCapture.java
@@ -1,5 +1,6 @@
 package com.RuneLingual.Widgets;
 
+import com.RuneLingual.LangCodeSelectableList;
 import com.RuneLingual.RuneLingualConfig;
 import com.RuneLingual.RuneLingualPlugin;
 import com.RuneLingual.SQL.SqlQuery;
@@ -14,13 +15,96 @@ import net.runelite.api.widgets.*;
 import net.runelite.api.gameval.InterfaceID.*;
 
 import javax.inject.Inject;
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.*;
 
 import static com.RuneLingual.Widgets.WidgetsUtilRLingual.removeBrAndTags;
 
 @Slf4j
 public class WidgetCapture {
+    private static final class BookPageState {
+        private final int sourceHash;
+        private final int renderedHash;
+        private final List<List<String>> translatedLinesByColumn;
+
+        private BookPageState(int sourceHash, int renderedHash, List<List<String>> translatedLinesByColumn) {
+            this.sourceHash = sourceHash;
+            this.renderedHash = renderedHash;
+            this.translatedLinesByColumn = translatedLinesByColumn;
+        }
+    }
+
+    private static int toInterfaceId(int componentId) {
+        return WidgetUtil.componentToInterface(componentId);
+    }
+
+    private static final Set<Integer> API_BOOK_SCROLL_INTERFACE_IDS = Set.of(
+            Book.UNIVERSE,
+            IndexedBook.UNIVERSE,
+            Bookofscrolls.UNIVERSE,
+            Journalscroll.UNIVERSE,
+            Questscroll.UNIVERSE,
+            QuestscrollSpeedrun.UNIVERSE,
+            Scroll.UNIVERSE,
+            IiScroll.UNIVERSE,
+            Longscroll.UNIVERSE,
+            Eventscroll.UNIVERSE,
+            HorrorPrayerbooks.UNIVERSE,
+            SideJournal.UNIVERSE,
+            Note.UNIVERSE,
+            GhorrockRequisitionNote.UNIVERSE,
+            toInterfaceId(Page.CONTENT_MODEL0),
+            toInterfaceId(Questjournal.INFINITY),
+            toInterfaceId(QuestjournalOverview.INFINITY),
+            toInterfaceId(Letterscroll.ROOT_MODEL0),
+            toInterfaceId(KingsLetterV2.KING_LETTER),
+            toInterfaceId(Elem2MaintenanceScroll.KING_LETTER),
+            toInterfaceId(SurokLetter1.ROOT_MODEL0),
+            toInterfaceId(SurokLetter2.ROOT_MODEL0),
+            toInterfaceId(ContactScrollBlood.ROOT_MODEL0),
+            toInterfaceId(WiseOldManScroll.ROOT_MODEL0),
+            toInterfaceId(ScrollGodfather.ROOT_MODEL0),
+            toInterfaceId(BarbassaultScrollPl1.ROOT_MODEL0),
+            toInterfaceId(BarbassaultScrollPl2.ROOT_MODEL0),
+            toInterfaceId(BlastFurnacePlanScroll.CONTENTS_MODEL0),
+            toInterfaceId(LostTribeSymbolBook.LOST_TRIBE_BOOK_COVER),
+            toInterfaceId(PengClockworkBookInterface.BOOK),
+            toInterfaceId(PogBolriesDiary.BACKGROUND_MODEL),
+            toInterfaceId(PohBookcase.INFINITE),
+            toInterfaceId(Messagescroll.ROOT_MODEL0),
+            toInterfaceId(Messagescroll2.MESSAGESCROLL2_CLOSE),
+            toInterfaceId(MessagescrollHandwriting.ROOT_MODEL0),
+            toInterfaceId(MessagescrollHandwriting2.ROOT_MODEL0),
+            toInterfaceId(MessagescrollHandwriting3.ROOT_MODEL0),
+            toInterfaceId(TrailCluetext.ROOT_MODEL0),
+            toInterfaceId(ChampionsScroll.ROOT_MODEL0),
+            Messagebox.UNIVERSE,
+            MessageboxTitled.UNIVERSE,
+            MessageboxUrl.UNIVERSE,
+            toInterfaceId(MmMessage.ROOT_MODEL0),
+            toInterfaceId(Fairy2Message.ROOT_MODEL0),
+            CluequestMap.UNIVERSE,
+            CoaTablet1.UNIVERSE,
+            CoaTablet2.UNIVERSE,
+            CoaTablet3.UNIVERSE,
+            CoaTablet4.UNIVERSE,
+            EyegloCluePanel.UNIVERSE,
+            toInterfaceId(EyegloGnomeMachineLocked.GNOME_MACHINE_BACKGROUND_LOCKED),
+            toInterfaceId(EyegloGnomeMachineUnlocked.MACHINE_UNLOACKED_BACKGROUND),
+            toInterfaceId(TrailClueEasyMap006.BG_SCROLL),
+            toInterfaceId(TrailClueHardMap006.BG_SCROLL),
+            toInterfaceId(TrailClueHardMap007.BG_SCROLL),
+            toInterfaceId(TrailClueMediumMap008.BG_SCROLL),
+            toInterfaceId(TrailClueMediumMap009.BG_SCROLL),
+            toInterfaceId(TrailClueMediumMap010.BG_SCROLL),
+            toInterfaceId(TrailClueMediumMap011.BG_SCROLL),
+            toInterfaceId(TrailClueMediumMap012.BG_SCROLL),
+            ChampionsLog.UNIVERSE,
+            KillLog.UNIVERSE,
+            FairyringsLog.UNIVERSE,
+            SailingLog.UNIVERSE
+    );
+
     @Inject
     private RuneLingualPlugin plugin;
     @Inject
@@ -37,6 +121,9 @@ public class WidgetCapture {
     private Ids ids;
     @Getter
     Set<String> pastTranslationResults = new HashSet<>();
+    private final Set<Integer> loggedBookFallbackGroups = new HashSet<>();
+    private final Set<Integer> processedBookLineParents = new HashSet<>();
+    private final Map<Integer, BookPageState> bookPageCache = new HashMap<>();
 
 
     @Inject
@@ -50,6 +137,7 @@ public class WidgetCapture {
          && plugin.getConfig().getNpcDialogueConfig() == RuneLingualConfig.ingameTranslationConfig.DONT_TRANSLATE) {
             return;
         }
+        processedBookLineParents.clear();
         Widget[] roots = client.getWidgetRoots();
         SqlQuery sqlQuery = new SqlQuery(this.plugin);
         for (Widget root : roots) {
@@ -102,10 +190,27 @@ public class WidgetCapture {
             return;
         }
 
+        boolean interfaceApiMode = plugin.getConfig().getInterfaceTextConfig() == RuneLingualConfig.ingameTranslationConfig.USE_API
+                && plugin.getConfig().ApiConfig();
+        boolean booksAndScrollsApiEnabled = plugin.getConfig().apiBooksAndScrolls();
+        boolean isApiBookOrScrollWidget = booksAndScrollsApiEnabled
+                && (API_BOOK_SCROLL_INTERFACE_IDS.contains(widgetGroup)
+                || shouldUseBookOrScrollFallbackApi(widget, widgetGroup));
+
+        // Book/scroll widgets do not always use WidgetType.TEXT + valid font ids.
+        // Handle them with a dedicated API path based on "has translatable text".
+        if (interfaceApiMode && isApiBookOrScrollWidget) {
+            translateWidgetApiBookOrScroll(widget);
+            return;
+        }
+
+        if (interfaceApiMode && shouldApiTranslateLobbyWidget(widget)) {
+            translateWidgetApiLobby(widget);
+            return;
+        }
+
         if(shouldTranslateWidget(widget)) {
-            if (plugin.getConfig().getInterfaceTextConfig() == RuneLingualConfig.ingameTranslationConfig.USE_API
-                 && plugin.getConfig().ApiConfig()) {
-                //translateWidgetApi(widget); //todo: disabled until mass api translation is seamless
+            if (interfaceApiMode) {
                 return;
             }
 
@@ -161,7 +266,456 @@ public class WidgetCapture {
         String text = widget.getText();
         Colors color = Colors.getColorArray(widget.getText(), Colors.getColorFromHex(Colors.IntToHex(widget.getTextColor())))[0];
         widgetsUtilRLingual.setWidgetText_ApiTranslation(widget, text, color);
+        widgetsUtilRLingual.changeLineHeight(widget);
         widgetsUtilRLingual.changeWidgetSize_ifNeeded(widget);
+    }
+
+    private void translateWidgetApiBookOrScroll(Widget widget) {
+        String text = widget.getText();
+        if (!shouldTranslateTextForBookOrScrollApi(text)) {
+            return;
+        }
+
+        if (isLikelyBookLineWidget(widget)) {
+            translateBookLineWidgetsByParent(widget);
+            return;
+        }
+        translateWidgetApi(widget);
+    }
+
+    private boolean shouldTranslateTextForBookOrScrollApi(String text) {
+        if (text == null) {
+            return false;
+        }
+        String modifiedText = Colors.removeAllTags(text).trim();
+        if (modifiedText.isEmpty()) {
+            return false;
+        }
+        if (!modifiedText.matches(".*[a-zA-Z].*")) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean shouldApiTranslateLobbyWidget(Widget widget) {
+        if (!plugin.getConfig().apiLobbyScreen() || !isInLobby()) {
+            return false;
+        }
+        if (!shouldTranslateWidget(widget)) {
+            return false;
+        }
+
+        String sourceText = Colors.removeNonImgTags(widget.getText()).trim();
+        if (sourceText.isEmpty() || !sourceText.matches(".*[a-zA-Z].*")) {
+            return false;
+        }
+        if (plugin.getDeepl().getDeeplPastTranslationManager().getTranslationResults().contains(sourceText)) {
+            return false;
+        }
+        return looksLikeEnglishSource(sourceText);
+    }
+
+    private void translateWidgetApiLobby(Widget widget) {
+        String sourceText = Colors.removeNonImgTags(widget.getText()).trim();
+        if (sourceText.isEmpty()) {
+            return;
+        }
+
+        String translatedText = plugin.getDeepl().translate(
+                sourceText,
+                LangCodeSelectableList.ENGLISH,
+                plugin.getConfig().getSelectedLanguage()
+        );
+        if (translatedText.equals(sourceText)) {
+            return;
+        }
+
+        Colors color = Colors.getColorArray(widget.getText(), Colors.getColorFromHex(Colors.IntToHex(widget.getTextColor())))[0];
+        widgetsUtilRLingual.setWidgetText_ApiTranslatedResolved(widget, translatedText, color, false);
+        widgetsUtilRLingual.changeLineHeight(widget);
+        widgetsUtilRLingual.changeWidgetSize_ifNeeded(widget);
+    }
+
+    private boolean isLikelyBookLineWidget(Widget widget) {
+        if (!hasBookPageNumberSibling(widget)) {
+            return false;
+        }
+        return widget.getHeight() > 0 && widget.getHeight() <= 45
+                && widget.getWidth() >= 60;
+    }
+
+    private void translateBookLineWidgetsByParent(Widget seedWidget) {
+        Widget parent = seedWidget.getParent();
+        if (parent == null) {
+            translateWidgetApi(seedWidget);
+            return;
+        }
+
+        int parentId = parent.getId();
+        if (!processedBookLineParents.add(parentId)) {
+            return;
+        }
+
+        List<Widget> bookLineWidgets = collectBookLineWidgets(parent);
+        if (bookLineWidgets.size() < 2) {
+            translateWidgetApi(seedWidget);
+            return;
+        }
+
+        List<List<Widget>> columns = splitIntoColumns(bookLineWidgets);
+        for (List<Widget> column : columns) {
+            column.sort(Comparator.comparingInt(w -> w.getBounds().y));
+        }
+
+        String sourceText = buildBookPageSourceText(columns);
+        if (sourceText.isEmpty()) {
+            return;
+        }
+
+        int sourceHash = sourceText.hashCode();
+        int currentRenderedHash = getTextHash(bookLineWidgets);
+        BookPageState cachedState = bookPageCache.get(parentId);
+
+        if (cachedState != null) {
+            if (currentRenderedHash == cachedState.renderedHash) {
+                return;
+            }
+            if (sourceHash == cachedState.sourceHash || !looksLikeEnglishSource(sourceText)) {
+                applyPageLines(columns, cachedState.translatedLinesByColumn);
+                return;
+            }
+        }
+
+        if (!looksLikeEnglishSource(sourceText)) {
+            return;
+        }
+
+        String translatedText = plugin.getDeepl().translate(
+                sourceText,
+                LangCodeSelectableList.ENGLISH,
+                plugin.getConfig().getSelectedLanguage()
+        );
+        if (translatedText.equals(sourceText)) {
+            return;
+        }
+
+        List<List<String>> translatedLinesByColumn = distributeTranslatedTextAcrossColumns(translatedText, columns);
+        applyPageLines(columns, translatedLinesByColumn);
+        int renderedHash = getTextHash(bookLineWidgets);
+        bookPageCache.put(parentId, new BookPageState(sourceHash, renderedHash, deepCopyLines(translatedLinesByColumn)));
+    }
+
+    private List<Widget> collectBookLineWidgets(Widget parent) {
+        List<Widget> result = new ArrayList<>();
+        for (Widget child : parent.getDynamicChildren()) {
+            if (isLikelyBookLineWidget(child) && shouldTranslateTextForBookOrScrollApi(child.getText())) {
+                result.add(child);
+            }
+        }
+        for (Widget child : parent.getNestedChildren()) {
+            if (isLikelyBookLineWidget(child) && shouldTranslateTextForBookOrScrollApi(child.getText())) {
+                result.add(child);
+            }
+        }
+        for (Widget child : parent.getStaticChildren()) {
+            if (isLikelyBookLineWidget(child) && shouldTranslateTextForBookOrScrollApi(child.getText())) {
+                result.add(child);
+            }
+        }
+        return result;
+    }
+
+    private List<List<Widget>> splitIntoColumns(List<Widget> bookLineWidgets) {
+        if (bookLineWidgets.size() < 2) {
+            return Collections.singletonList(bookLineWidgets);
+        }
+
+        int minX = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE;
+        for (Widget widget : bookLineWidgets) {
+            Rectangle bounds = widget.getBounds();
+            minX = Math.min(minX, bounds.x);
+            maxX = Math.max(maxX, bounds.x);
+        }
+
+        if (maxX - minX < 120) {
+            return Collections.singletonList(bookLineWidgets);
+        }
+
+        int splitX = minX + ((maxX - minX) / 2);
+        List<Widget> left = new ArrayList<>();
+        List<Widget> right = new ArrayList<>();
+
+        for (Widget widget : bookLineWidgets) {
+            Rectangle bounds = widget.getBounds();
+            int centerX = bounds.x + (Math.max(bounds.width, 1) / 2);
+            if (centerX <= splitX) {
+                left.add(widget);
+            } else {
+                right.add(widget);
+            }
+        }
+
+        if (left.isEmpty() || right.isEmpty()) {
+            return Collections.singletonList(bookLineWidgets);
+        }
+
+        List<List<Widget>> columns = new ArrayList<>(2);
+        columns.add(left);
+        columns.add(right);
+        return columns;
+    }
+
+    private String buildBookPageSourceText(List<List<Widget>> columns) {
+        List<String> columnTexts = new ArrayList<>();
+        for (List<Widget> column : columns) {
+            List<String> sourceLines = new ArrayList<>();
+            for (Widget widget : column) {
+                String text = Colors.removeAllTags(widget.getText()).trim();
+                if (!text.isEmpty()) {
+                    sourceLines.add(text);
+                }
+            }
+            if (!sourceLines.isEmpty()) {
+                columnTexts.add(String.join(" ", sourceLines));
+            }
+        }
+        return String.join(" ", columnTexts).trim();
+    }
+
+    private List<List<String>> distributeTranslatedTextAcrossColumns(String translatedText, List<List<Widget>> columns) {
+        List<Integer> slotCapacities = new ArrayList<>();
+        List<Integer> columnLineCounts = new ArrayList<>();
+
+        for (List<Widget> column : columns) {
+            int lineCount = column.size();
+            columnLineCounts.add(lineCount);
+
+            int minWidth = column.stream().mapToInt(Widget::getWidth).filter(w -> w > 0).min().orElse(120);
+            int charWidth = Math.max(1, LangCodeSelectableList.getLatinCharWidth(column.get(0), plugin.getConfig().getSelectedLanguage()));
+            int maxCharsPerLine = Math.max(6, (int) Math.floor((minWidth / (double) charWidth) * 0.72));
+            for (int i = 0; i < lineCount; i++) {
+                slotCapacities.add(maxCharsPerLine);
+            }
+        }
+
+        List<String> slotLines = wrapTextToCapacitySlots(translatedText, slotCapacities);
+        List<List<String>> linesByColumn = new ArrayList<>();
+        int cursor = 0;
+        for (int columnIndex = 0; columnIndex < columnLineCounts.size(); columnIndex++) {
+            int count = columnLineCounts.get(columnIndex);
+            List<String> lines = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                lines.add(cursor < slotLines.size() ? slotLines.get(cursor) : "");
+                cursor++;
+            }
+            linesByColumn.add(lines);
+        }
+        return linesByColumn;
+    }
+
+    private List<String> wrapTextToCapacitySlots(String text, List<Integer> capacities) {
+        if (capacities.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<String> normalizedWords = new ArrayList<>();
+        for (String word : text.trim().split("\\s+")) {
+            if (!word.isEmpty()) {
+                normalizedWords.add(word);
+            }
+        }
+
+        List<String> lines = new ArrayList<>(Collections.nCopies(capacities.size(), ""));
+        int wordIndex = 0;
+
+        for (int slot = 0; slot < capacities.size(); slot++) {
+            int capacity = Math.max(1, capacities.get(slot));
+            StringBuilder line = new StringBuilder();
+
+            while (wordIndex < normalizedWords.size()) {
+                String word = normalizedWords.get(wordIndex);
+                if (word.length() > capacity) {
+                    if (line.length() == 0) {
+                        line.append(word, 0, capacity);
+                        normalizedWords.set(wordIndex, word.substring(capacity));
+                    }
+                    break;
+                }
+
+                if (line.length() == 0) {
+                    line.append(word);
+                    wordIndex++;
+                    continue;
+                }
+
+                if (line.length() + 1 + word.length() <= capacity) {
+                    line.append(' ').append(word);
+                    wordIndex++;
+                } else {
+                    break;
+                }
+            }
+
+            lines.set(slot, line.toString());
+        }
+
+        if (wordIndex < normalizedWords.size()) {
+            StringBuilder tail = new StringBuilder(lines.get(lines.size() - 1));
+            for (int i = wordIndex; i < normalizedWords.size(); i++) {
+                String word = normalizedWords.get(i);
+                if (word.isEmpty()) {
+                    continue;
+                }
+                if (tail.length() > 0) {
+                    tail.append(' ');
+                }
+                tail.append(word);
+            }
+            lines.set(lines.size() - 1, tail.toString());
+        }
+
+        return lines;
+    }
+
+    private void applyPageLines(List<List<Widget>> columns, List<List<String>> translatedLinesByColumn) {
+        int columnCount = Math.min(columns.size(), translatedLinesByColumn.size());
+        for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+            List<Widget> widgets = columns.get(columnIndex);
+            List<String> lines = translatedLinesByColumn.get(columnIndex);
+            for (int i = 0; i < widgets.size(); i++) {
+                String newLine = i < lines.size() ? lines.get(i) : "";
+                widgets.get(i).setText(newLine);
+            }
+        }
+    }
+
+    private List<List<String>> deepCopyLines(List<List<String>> linesByColumn) {
+        List<List<String>> copy = new ArrayList<>();
+        for (List<String> lines : linesByColumn) {
+            copy.add(new ArrayList<>(lines));
+        }
+        return copy;
+    }
+
+    private boolean looksLikeEnglishSource(String text) {
+        String t = text == null ? "" : text.trim();
+        if (t.isEmpty()) {
+            return false;
+        }
+
+        int asciiLetters = 0;
+        int accentedLetters = 0;
+        for (int i = 0; i < t.length(); i++) {
+            char ch = t.charAt(i);
+            if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')) {
+                asciiLetters++;
+            } else if ((ch >= 192 && ch <= 255) || ch == 'ã' || ch == 'õ' || ch == 'ç' || ch == 'á' || ch == 'é'
+                    || ch == 'í' || ch == 'ó' || ch == 'ú' || ch == 'â' || ch == 'ê' || ch == 'ô') {
+                accentedLetters++;
+            }
+        }
+
+        if (asciiLetters == 0) {
+            return false;
+        }
+        return accentedLetters * 4 < asciiLetters;
+    }
+
+
+    private int getTextHash(List<Widget> widgets) {
+        StringBuilder builder = new StringBuilder();
+        widgets.stream()
+                .sorted(Comparator.comparingInt((Widget w) -> w.getBounds().x).thenComparingInt(w -> w.getBounds().y))
+                .forEach(w -> builder.append(w.getId()).append('=').append(w.getText()).append('\n'));
+        return builder.toString().hashCode();
+    }
+
+    private boolean shouldUseBookOrScrollFallbackApi(Widget widget, int widgetGroup) {
+        String text = widget.getText();
+        if (!shouldTranslateTextForBookOrScrollApi(text)) {
+            return false;
+        }
+
+        // Don't target chat widgets with long text.
+        if (isChildWidgetOf(widget, Chatbox.CHATDISPLAY)
+                || isChildWidgetOf(widget, ComponentID.CHATBOX_BUTTONS)
+                || widget.getId() == Chatbox.SCROLLAREA) {
+            return false;
+        }
+
+        String strippedText = Colors.removeAllTags(text).trim();
+        int width = widget.getWidth();
+        int height = widget.getHeight();
+        boolean isLongTextBlock = strippedText.length() >= 80;
+        boolean looksLikeBookLine = hasBookPageNumberSibling(widget)
+                && strippedText.length() >= 8
+                && width >= 60
+                && height >= 10
+                && height <= 40;
+        boolean looksLikeReadablePanelLine = isInsideLargeReadablePanel(widget)
+                && strippedText.length() >= 16
+                && width >= 80
+                && height >= 10
+                && height <= 45;
+
+        if (!isLongTextBlock && !looksLikeBookLine && !looksLikeReadablePanelLine) {
+            return false;
+        }
+
+        if (loggedBookFallbackGroups.add(widgetGroup)) {
+            String preview = strippedText.length() > 64 ? strippedText.substring(0, 64) + "..." : strippedText;
+            log.info("RuneLingual book/scroll API fallback matched group={}, widgetId={}, type={}, font={}, size={}x{}, text='{}'",
+                    widgetGroup, widget.getId(), widget.getType(), widget.getFontId(), width, height, preview);
+        }
+        return true;
+    }
+
+    private boolean hasBookPageNumberSibling(Widget widget) {
+        Widget parent = widget.getParent();
+        if (parent == null) {
+            return false;
+        }
+
+        int pageLikeSiblings = 0;
+        for (Widget child : parent.getDynamicChildren()) {
+            if (isPageNumberLike(child)) {
+                pageLikeSiblings++;
+            }
+        }
+        for (Widget child : parent.getNestedChildren()) {
+            if (isPageNumberLike(child)) {
+                pageLikeSiblings++;
+            }
+        }
+        for (Widget child : parent.getStaticChildren()) {
+            if (isPageNumberLike(child)) {
+                pageLikeSiblings++;
+            }
+        }
+        return pageLikeSiblings >= 2;
+    }
+
+    private boolean isPageNumberLike(Widget widget) {
+        if (widget == null || widget.getText() == null) {
+            return false;
+        }
+        String t = Colors.removeAllTags(widget.getText()).trim();
+        if (!t.matches("\\d{1,2}")) {
+            return false;
+        }
+        return widget.getWidth() <= 40 && widget.getHeight() <= 30;
+    }
+
+    private boolean isInsideLargeReadablePanel(Widget widget) {
+        Widget parent = widget.getParent();
+        while (parent != null) {
+            if (parent.getWidth() >= 260 && parent.getHeight() >= 160) {
+                return true;
+            }
+            parent = parent.getParent();
+        }
+        return false;
     }
 
     private void modifySqlQuery4Widget(Widget widget, SqlQuery sqlQuery) {
@@ -500,4 +1054,3 @@ public class WidgetCapture {
         return loginWidget != null && !loginWidget.isHidden();
     }
 }
-

--- a/src/main/java/com/RuneLingual/Widgets/WidgetsUtilRLingual.java
+++ b/src/main/java/com/RuneLingual/Widgets/WidgetsUtilRLingual.java
@@ -70,6 +70,10 @@ public class WidgetsUtilRLingual
 		// Preserve those instead of stripping <br> and re-wrapping, which can look like "Enter" was pressed.
 		final boolean preserveBr = ids.getWidgetId2KeepBr().contains(widget.getId())
 				|| ids.getWidgetId2SplitTextAtBr().contains(widget.getId());
+		final boolean shouldForceColTag = !plugin.getTargetLanguage().needsCharImages()
+				&& color != null
+				// Some widgets rely on <col> tags for visibility (textColor can be 0/transparent).
+				&& (originalText.contains("<col") || widget.getTextColor() == 0);
 
 		if (!preserveBr) {
 			final String textWithoutBrAndTags = sanitizeTranslatedWidgetText(Colors.removeNonImgTags(originalText));
@@ -83,6 +87,10 @@ public class WidgetsUtilRLingual
 				translatedText = generalFunctions.StringToTags(translatedText, color);
 			}
 			setWidgetText_NiceBr(widget, translatedText);
+			if (shouldForceColTag) {
+				// Wrap after NiceBr so tag length doesn't interfere with auto <br> insertion.
+				widget.setText(Colors.surroundWithColorTag(widget.getText(), color));
+			}
 			return;
 		}
 
@@ -118,7 +126,11 @@ public class WidgetsUtilRLingual
 			return;
 		}
 
-		widget.setText(sb.toString());
+		String out = sb.toString();
+		if (shouldForceColTag) {
+			out = Colors.surroundWithColorTag(out, color);
+		}
+		widget.setText(out);
 	}
 
 	public void setWidgetText_ApiTranslationSingleLine(Widget widget, String originalText, Colors color) {

--- a/src/main/java/com/RuneLingual/Widgets/WidgetsUtilRLingual.java
+++ b/src/main/java/com/RuneLingual/Widgets/WidgetsUtilRLingual.java
@@ -62,16 +62,63 @@ public class WidgetsUtilRLingual
 	}
 
 	public void setWidgetText_ApiTranslation(Widget widget, String originalText, Colors color){
-		final String text_withoutBrAndTags = Colors.removeNonImgTags(originalText);
-		String translatedText = plugin.getDeepl().translate(text_withoutBrAndTags, LangCodeSelectableList.ENGLISH, plugin.getConfig().getSelectedLanguage());
-		if(translatedText.equals(text_withoutBrAndTags)) { // if the translation is the same as the original text, don't set the text
+		if (originalText == null) {
 			return;
 		}
 
-		if (plugin.getTargetLanguage().needsCharImages()) {
-			translatedText = generalFunctions.StringToTags(translatedText, color);
+		// Some widgets (eg: Prayer/Spellbook tooltips) rely on explicit <br> lines.
+		// Preserve those instead of stripping <br> and re-wrapping, which can look like "Enter" was pressed.
+		final boolean preserveBr = ids.getWidgetId2KeepBr().contains(widget.getId())
+				|| ids.getWidgetId2SplitTextAtBr().contains(widget.getId());
+
+		if (!preserveBr) {
+			final String textWithoutBrAndTags = sanitizeTranslatedWidgetText(Colors.removeNonImgTags(originalText));
+			String translatedText = plugin.getDeepl().translate(textWithoutBrAndTags, LangCodeSelectableList.ENGLISH, plugin.getConfig().getSelectedLanguage());
+			translatedText = sanitizeTranslatedWidgetText(translatedText);
+			if (translatedText.equals(textWithoutBrAndTags)) { // if the translation is the same as the original text, don't set the text
+				return;
+			}
+
+			if (plugin.getTargetLanguage().needsCharImages()) {
+				translatedText = generalFunctions.StringToTags(translatedText, color);
+			}
+			setWidgetText_NiceBr(widget, translatedText);
+			return;
 		}
-		setWidgetText_NiceBr(widget, translatedText);
+
+		String[] parts = originalText.split("<br>");
+		StringBuilder sb = new StringBuilder();
+		boolean anyChanged = false;
+
+		for (int i = 0; i < parts.length; i++) {
+			String partPlain = sanitizeTranslatedWidgetText(Colors.removeNonImgTags(parts[i]));
+			if (partPlain.isEmpty()) {
+				// Keep blank lines as-is.
+				if (i != parts.length - 1) {
+					sb.append("<br>");
+				}
+				continue;
+			}
+			String translatedPart = plugin.getDeepl().translate(partPlain, LangCodeSelectableList.ENGLISH, plugin.getConfig().getSelectedLanguage());
+			translatedPart = sanitizeTranslatedWidgetText(translatedPart);
+			if (!translatedPart.equals(partPlain)) {
+				anyChanged = true;
+			}
+			if (plugin.getTargetLanguage().needsCharImages()) {
+				// Convert line-by-line so <br> tags are not consumed by the char-image converter.
+				translatedPart = generalFunctions.StringToTags(translatedPart, color);
+			}
+			sb.append(translatedPart);
+			if (i != parts.length - 1) {
+				sb.append("<br>");
+			}
+		}
+
+		if (!anyChanged) {
+			return;
+		}
+
+		widget.setText(sb.toString());
 	}
 
 	public void setWidgetText_ApiTranslationSingleLine(Widget widget, String originalText, Colors color) {
@@ -316,6 +363,22 @@ public class WidgetsUtilRLingual
 	public void changeLineHeight(Widget widget) {
 		int lineHeight = plugin.getConfig().getSelectedLanguage().getCharHeight();
 		widget.setLineHeight(lineHeight);
+	}
+
+	private static String sanitizeTranslatedWidgetText(String text) {
+		if (text == null) {
+			return "";
+		}
+		// Prevent raw newlines/line-separators from showing as "empty squares" or breaking layout.
+		String sanitized = text
+				.replace("\r\n", " ")
+				.replace('\n', ' ')
+				.replace('\r', ' ')
+				.replace('\u2028', ' ')
+				.replace('\u2029', ' ');
+		// Collapse repeated whitespace.
+		sanitized = sanitized.replaceAll("\\s{2,}", " ").trim();
+		return sanitized;
 	}
 
 }

--- a/src/main/java/com/RuneLingual/Widgets/WidgetsUtilRLingual.java
+++ b/src/main/java/com/RuneLingual/Widgets/WidgetsUtilRLingual.java
@@ -11,6 +11,7 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetSizeMode;
 
 import javax.inject.Inject;
+import java.text.Normalizer;
 
 public class WidgetsUtilRLingual
 {
@@ -109,6 +110,10 @@ public class WidgetsUtilRLingual
 			}
 			String translatedPart = plugin.getDeepl().translate(partPlain, LangCodeSelectableList.ENGLISH, plugin.getConfig().getSelectedLanguage());
 			translatedPart = sanitizeTranslatedWidgetText(translatedPart);
+			if (translatedPart.isBlank()) {
+				// Defensive: avoid rendering an empty line (can look like a blank tooltip in some fonts).
+				translatedPart = partPlain;
+			}
 			if (!translatedPart.equals(partPlain)) {
 				anyChanged = true;
 			}
@@ -381,13 +386,49 @@ public class WidgetsUtilRLingual
 		if (text == null) {
 			return "";
 		}
-		// Prevent raw newlines/line-separators from showing as "empty squares" or breaking layout.
-		String sanitized = text
+
+		String sanitized = Normalizer.normalize(text, Normalizer.Form.NFKC);
+
+		// Prevent raw newlines/line-separators from breaking layout.
+		sanitized = sanitized
 				.replace("\r\n", " ")
 				.replace('\n', ' ')
 				.replace('\r', ' ')
 				.replace('\u2028', ' ')
 				.replace('\u2029', ' ');
+
+		// Replace common "unsupported glyph" characters with simpler ASCII punctuation.
+		sanitized = sanitized
+				.replace('\u00A0', ' ')      // NBSP
+				.replace("\uFEFF", "")      // BOM
+				.replace("\u200B", "")      // zero width space
+				.replace("\u200C", "")      // zero width non-joiner
+				.replace("\u200D", "")      // zero width joiner
+				.replace("\u2060", "")      // word joiner
+				.replace('\u2018', '\'')    // left single quote
+				.replace('\u2019', '\'')    // right single quote
+				.replace('\u201A', '\'')
+				.replace('\u201B', '\'')
+				.replace('\u02BC', '\'')
+				.replace('\u201C', '"')     // left double quote
+				.replace('\u201D', '"')     // right double quote
+				.replace('\u201E', '"')
+				.replace('\u00AB', '"')     // guillemet left
+				.replace('\u00BB', '"')     // guillemet right
+				.replace('\u2010', '-')     // hyphen
+				.replace('\u2011', '-')     // non-breaking hyphen
+				.replace('\u2012', '-')     // figure dash
+				.replace('\u2013', '-')     // en dash
+				.replace('\u2014', '-')     // em dash
+				.replace('\u2212', '-')     // minus
+				.replace('\u00AD', '-')     // soft hyphen
+				.replace('\u2022', '*')     // bullet
+				.replace('\u00B7', '.')     // middle dot
+				.replace("\u2026", "...");  // ellipsis
+
+		// Remove remaining control characters (often render as empty squares).
+		sanitized = sanitized.replaceAll("[\\u0000-\\u001F\\u007F]+", " ");
+
 		// Collapse repeated whitespace.
 		sanitized = sanitized.replaceAll("\\s{2,}", " ").trim();
 		return sanitized;

--- a/src/main/java/com/RuneLingual/Widgets/WidgetsUtilRLingual.java
+++ b/src/main/java/com/RuneLingual/Widgets/WidgetsUtilRLingual.java
@@ -64,7 +64,6 @@ public class WidgetsUtilRLingual
 	public void setWidgetText_ApiTranslation(Widget widget, String originalText, Colors color){
 		final String text_withoutBrAndTags = Colors.removeNonImgTags(originalText);
 		String translatedText = plugin.getDeepl().translate(text_withoutBrAndTags, LangCodeSelectableList.ENGLISH, plugin.getConfig().getSelectedLanguage());
-		int originalLineHeight = widget.getLineHeight();
 		if(translatedText.equals(text_withoutBrAndTags)) { // if the translation is the same as the original text, don't set the text
 			return;
 		}
@@ -73,7 +72,33 @@ public class WidgetsUtilRLingual
 			translatedText = generalFunctions.StringToTags(translatedText, color);
 		}
 		setWidgetText_NiceBr(widget, translatedText);
-		widget.setLineHeight(originalLineHeight);
+	}
+
+	public void setWidgetText_ApiTranslationSingleLine(Widget widget, String originalText, Colors color) {
+		final String textWithoutBrAndTags = Colors.removeNonImgTags(originalText);
+		String translatedText = plugin.getDeepl().translate(textWithoutBrAndTags, LangCodeSelectableList.ENGLISH, plugin.getConfig().getSelectedLanguage());
+		if (translatedText.equals(textWithoutBrAndTags)) {
+			return;
+		}
+
+		if (plugin.getTargetLanguage().needsCharImages()) {
+			translatedText = generalFunctions.StringToTags(translatedText, color);
+		}
+		widget.setText(translatedText);
+	}
+
+	public void setWidgetText_ApiTranslatedResolved(Widget widget, String translatedText, Colors color, boolean singleLine) {
+		if (translatedText == null || translatedText.isBlank()) {
+			return;
+		}
+		if (plugin.getTargetLanguage().needsCharImages()) {
+			translatedText = generalFunctions.StringToTags(translatedText, color);
+		}
+		if (singleLine) {
+			widget.setText(translatedText);
+			return;
+		}
+		setWidgetText_NiceBr_apiTranslated(widget, translatedText);
 	}
 
 	private void setWidgetText_NiceBr_CharImages(Widget widget, String newText) {
@@ -156,7 +181,7 @@ public class WidgetsUtilRLingual
 		// if newText doesnt have <br> tag at all, insert br automatically
 		if (!newText.contains("<br>")) {
 			newText = newText.replaceAll("<autoBr>|</autoBr>", ""); // remove <autoBr> tags
-			newText = getWidgetText_NiceBr_CharImages(widget, newText);
+			newText = getWidgetText_NiceBr_NoCharImages(widget, newText);
 			widget.setText(newText);
 			return;
 		}

--- a/src/main/java/com/RuneLingual/commonFunctions/Ids.java
+++ b/src/main/java/com/RuneLingual/commonFunctions/Ids.java
@@ -91,6 +91,8 @@ public class Ids {
     private final Set<Integer> widgetIdNot2Translate = Set.of(
             Chatbox.CHATDISPLAY,
             10617391,//some sort of background for chatbox
+            // Report Abuse interface is layout-sensitive; changing text/line height can break the rule numbering UI.
+            Reportabuse.UNIVERSE,
             widgetIdCharacterSummaryName,
             Ignore.LIST_CONTAINER,
             widgetIdGimGroupName, //gim group name in group tab

--- a/src/main/resources/runelite-plugin.properties
+++ b/src/main/resources/runelite-plugin.properties
@@ -1,0 +1,5 @@
+displayName=RuneLingual
+author=IaKee, YS-jack
+description=All-in-one translation plugin.
+tags=translation, language, 日本語
+plugins=com.RuneLingual.RuneLingualPlugin


### PR DESCRIPTION
## Summary
- keep original local text for transformed outgoing chat while still sending translated text to server
- add safer outgoing transform flow for public/friends/clan/gim channels
- add API translation support for books/scrolls/notes and translate book pages in a single API request per page
- add optional API translation for lobby/login widget texts
- add DeepL request guardrails (header/request size limits, free-tier monthly cap handling, and congestion backoff)

## Technical Changes
- update outgoing chat script callback/send flow in `RuneLingualPlugin`
- add/adjust config options in `RuneLingualConfig`
- extend widget API translation pipeline in `WidgetCapture` and `WidgetsUtilRLingual`
- harden DeepL client request behavior in `ApiTranslate/Deepl`
- include supporting updates in chat capture classes/build setup

## Validation
- `./gradlew --no-daemon clean shadowJar`
- manual in-game checks for:
  - outgoing transform showing original text locally
  - public/friends/clan outgoing API transform
  - clue/books/notes API translation
  - lobby/login widget translation toggle
  - DeepL congestion handling behavior
