### PR TITLE
Editing codes (see description)

### DIFF
--- a/README_deveploers.md
+++ b/README_deveploers.md
@@ -43,8 +43,25 @@ These files include:
 - **Bank Tags**: Add bank tags to every item for searching in the selected language (may not be possible).
 - **Plugin Compatibility**: Ensure compatibility with other useful plugins like the menu entry swapper and ground marker. This may involve creating similar versions within this plugin or making pull requests to those plugins.
 
-## 6. Collecting Widget IDs
-### 6.1 Obtain Widget ID
+## 6. Translation Fallback Chain (P1-P5)
+
+When looking up a translation in the database, the plugin uses a priority-based fallback chain. "P" stands for **Priority** -- each step relaxes the matching criteria further, and only falls through to the next when no match is found:
+```
+P1: english + category + subCategory + source  (most precise)
+P2: english + category + subCategory
+P3: english + category
+P4: english only, case-insensitive
+P5: english only, fuzzy (strips all spaces/punctuation, compares letters+digits only)
+```
+
+### When to set up Widget IDs
+
+The more context (category / subCategory / source) you provide, the more precise P1-P3 can be. This extra precision prevents a translation intended for one UI context from accidentally matching text in another.
+
+However, **P4 and P5 do not need any category information at all**. If you are unsure how to collect Widget IDs (see section 7), you can skip it entirely -- the plugin will still translate text via P4 and P5 with reasonable coverage.
+
+## 7. Collecting Widget IDs
+### 7.1 Obtain Widget ID
 Get the Widget ID of the parent that contains the text you want to translate, by using the Widget Inspector. You need [developer mode](https://github.com/runelite/runelite/wiki/Using-the-client-developer-tools) for this.
 <br> After enabling developer mode,
    - (1) open the widget inspector by clicking on the new cog icon on the right side of the client
@@ -59,7 +76,7 @@ Get the Widget ID of the parent that contains the text you want to translate, by
 - <i>Note: If (3) in the picture has a name instead of codes like the above case, you can use the name instead of the ID, explained below</i>
 <br><img src="Readmes/toDevsImg/parentOfArdy.png" width="500">
    
-### 6.2 Add ID to Script
+### 7.2 Add ID to Script
 Add the ID to [Ids class](src/main/java/com/RuneLingual/commonFunctions/Ids.java) below line 64, like:
 ```java
 private final int widgetIdWorldSwitcherTab = 4521984;
@@ -79,7 +96,7 @@ private final Set<Integer> widgetIdSet = new HashSet<>(Arrays.asList(
 There will be many widgets to go through, so categorizing them will help improve readability and organization.
 <br><i>If any widgets under the parent are dynamic (i.e., item name, player name), refer to the next section</i>
 
-### 6.3. Add to SqlVariables
+### 7.3. Add to SqlVariables
 Add corresponding sql values to [SqlVariables class](src/main/java/com/RuneLingual/Sql/SqlVariables.java), below line 62. 
 Name should be `"sourceValue4" + the name of the source`. <br>For example:
 ```java
@@ -87,7 +104,7 @@ sourceValue4SkillGuideInterface("skillGuide","source"), // for skill guide inter
 ```
 The second value "source" should not be changed, as it is the name of the column in the database.
 
-### 6.4. Add to WidgetCapture
+### 7.4. Add to WidgetCapture
 Go to [WidgetCapture class'](src/main/java/com/RuneLingual/Widgets/WidgetCapture.java) `modifySqlQuery4Widget` function and an `if` statement to in the form of
 ```java
 if(widgetId == ids.getNameOfIdInStep2){
@@ -102,7 +119,7 @@ if(ids.getWidgetIdSetInStep2().contains(widgetId)){
 ```
 
 
-### 6.5 Edit Output Function
+### 7.5 Edit Output Function
 After that, also in the same WidgetCapture class, edit the `ifIsDumpTarget_thenDump` function, change the first if statement to detect the widget you want to capture, like:
 ```java
 if (sqlQuery.getSource() != null && sqlQuery.getSource().equals(SqlVariables.NameInStep3.getValue())){
@@ -110,7 +127,7 @@ if (sqlQuery.getSource() != null && sqlQuery.getSource().equals(SqlVariables.Nam
 ```
 Then change the file name variable `String fileName` to something appropriate, and doesnt exist yet in the `dump` folder.
 You don't have to change anything else.
-### 6.6 Check Output
+### 7.6 Check Output
 Run the plugin and open the interface you want to capture. You should see the text file in the `RuneLingual-Plugin/output/dump` folder.
 <br>The output should look like this:
 ```
@@ -119,16 +136,16 @@ Members: Soulreaper axe (with <Num0> Strength)		interface	generalUI	skillGuide
 Members: Variants of Keris partisan (requires Beneath Cursed Sands)		interface	generalUI	skillGuide
 Members: Osmumten's Fang		interface	generalUI	skillGuide
 ```
-### 6.7 Check with devs
+### 7.7 Check with devs
 If this is your first time, be sure to make a PR to the latest branch so someone can check you are doing thing right.
 
-## 7.1 Dynamic Texts
+## 8.1 Dynamic Texts
 ### There are 2 types of Dynamic texts
 <br><img src="Readmes/toDevsImg/dynamicTexts.png" width="400">
 1. Only dynamic, such as item names, player names, etc.
 2. Partially dynamic, such as "Name: (player name)" in the picture above.
 
-### 7.1.1 Dynamic Only
+### 8.1.1 Dynamic Only
 For widgets with <b><u>DYNAMIC ONLY</u></b> texts, like item name, player name, add the ID to the corresponding set in [Ids class](src/main/java/com/RuneLingual/commonFunctions/Ids.java).
 ```java
 private final Set<Integer> widgetIdPlayerName = Set.of(
@@ -155,7 +172,7 @@ private final Set<Integer> widgetIdQuestName = Set.of(
 );
 ```
 <br>If you find other types of dynamic texts, we could make a new set, talk to the devs on Discord.
-### 7.1.2 Partially Dynamic
+### 8.1.2 Partially Dynamic
 For widgets that are <u><b>PARTIALLY DYNAMIC</b></u>, such as "Name: (player name)", you need to add an object to the PartialTranslationManager in [Ids class](src/main/java/com/RuneLingual/commonFunctions/Ids.java).
 ```java
 partialTranslationManager.addPartialTranslation(
@@ -172,8 +189,8 @@ partialTranslationManager.addPartialTranslation(
 ```
 This will capture the text "Name: (player name)", replace the dynamic part with a placeholder.
 
-## 7.2 Other Specifications
-### 7.2.1 Configure Widget To Fit Text
+## 8.2 Other Specifications
+### 8.2.1 Configure Widget To Fit Text
 - If the widget size needs to change according to the amount of text it contains, such as
 <br><img src="Readmes/toDevsImg/widget2Mod_before.png" width="200">
 <br>add it to [Ids class](src/main/java/com/RuneLingual/commonFunctions/Ids.java)'s initWidget2ModDict:
@@ -203,7 +220,7 @@ This will capture the text "Name: (player name)", replace the dynamic part with 
 <br><br><i> If top is fixed, the top part won't move, and it will expand/shrink at the bottom edge. Same goes for others.</i>
 <br><i> If top and bottom / left and right are both fixed, it will not resize vertically / horizontally.</i>
 <br><i> If both top and bottom / left and right are not fixed, it will try to expand/shrink equally on both sides.</i>
-### 7.2.2 Specifying Widget Size
+### 8.2.2 Specifying Widget Size
 - To make widget size needs to a <b><u>Fixed size</u></b> like 
 <br><img src="Readmes/toDevsImg/SpecifyWidth.png" width="200">(make it as big as possible to fit as much letters)
 <br>add it to [Ids class](src/main/java/com/RuneLingual/commonFunctions/Ids.java)'s widgetId2FixedSize:
@@ -215,7 +232,7 @@ This will capture the text "Name: (player name)", replace the dynamic part with 
     ```
   After adding to the widgetId2FixedSize, it will automatically set the widget size to the specified size.
 
-### 7.2.3 Splitting Texts
+### 8.2.3 Splitting Texts
 - If the text is split by `<br>` tags, and there are repetitive texts, such as the XP hover which looks like:
     ```
     Agility XP:<br>Next level at:<br>Remaining XP:
@@ -232,7 +249,7 @@ This will capture the text "Name: (player name)", replace the dynamic part with 
     ```
     This will split the text at the `<br>` tags and translate the repetitive parts only once.
 
-### 7.2.4 Useful Tags
+### 8.2.4 Useful Tags
 I have implemented some tags to make the translation process easier.<br>The tags are as follows:
   - The <b>asis</b> tag allows you to specify parts that should be displayed as is, without translation nor replaced with char iamges.<br>Usage: ```<asis>text to display as is</asis>```
   - The <b>```<Num#>```</b> tag is a placeholder for numbers and represents a specific number, so it can contain any number.<br> This was implemented to reduce the number of translations that differ only by numbers.<br>This should be automatically be inserted inplace of numbers automatically.

--- a/README_deveploers.md
+++ b/README_deveploers.md
@@ -51,7 +51,7 @@ P1: english + category + subCategory + source  (most precise)
 P2: english + category + subCategory
 P3: english + category
 P4: english only, case-insensitive
-P5: english only, fuzzy (strips all spaces/punctuation, compares letters+digits only)
+P5: fuzzy match in english (strip all non-alphanumeric chars, compare case-insensitive) + category + subCategory
 ```
 
 ### When to set up Widget IDs

--- a/src/main/java/com/RuneLingual/ChatMessages/ChatCapture.java
+++ b/src/main/java/com/RuneLingual/ChatMessages/ChatCapture.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.tuple.Pair;
 @Slf4j
 public class ChatCapture
 {
+    private static final String TRANSLATOR_SENDER = "RuneLingual";
     /* Captures chat messages from any source
     ignores npc dialog, as they are handled in DialogCapture*/
 
@@ -86,6 +87,9 @@ public class ChatCapture
 
 
     public void handleChatMessage(ChatMessage chatMessage) throws Exception {
+        if (TRANSLATOR_SENDER.equals(chatMessage.getSender())) {
+            return;
+        }
         ChatMessageType type = chatMessage.getType();
         MessageNode messageNode = chatMessage.getMessageNode();
         String message = chatMessage.getMessage();// e.g.<col=6800bf>Some cracks around the cave begin to ooze water.
@@ -185,7 +189,7 @@ public class ChatCapture
                 }
                 return; // if the message is not translated, do not replace it
             }
-        replaceChatMessage(translatedMessage, node);
+        replaceChatMessage(translatedMessage, node, chatMessage);
     }
     
     private void onlineTranslator(String message, MessageNode node, ChatMessage chatMessage)
@@ -205,7 +209,7 @@ public class ChatCapture
         Transformer transformer = new Transformer(plugin);
         Colors textColor = chatColorManager.getMessageColor();
         String textToDisplay = transformer.stringToDisplayedString(translation, textColor);
-        replaceChatMessage(textToDisplay, node);
+        replaceChatMessage(textToDisplay, node, chatMessage);
         addMsgToSidePanel(chatMessage, translation);
     }
 
@@ -214,11 +218,25 @@ public class ChatCapture
         Transformer transformer = new Transformer(plugin);
         Colors textColor = chatColorManager.getMessageColor();
         String textToDisplay = transformer.stringToDisplayedString(newMessage, textColor);
-        replaceChatMessage(textToDisplay, node);
+        replaceChatMessage(textToDisplay, node, chatMessage);
         addMsgToSidePanel(chatMessage, newMessage);
     }
 
-    private void replaceChatMessage(String newMessage, MessageNode node) {
+    private void replaceChatMessage(String newMessage, MessageNode node, ChatMessage chatMessage) {
+        if (plugin.getConfig().getChatDisplayMode() == RuneLingualConfig.ChatDisplayMode.ADD_TRANSLATOR_MSG) {
+            String senderName = Colors.removeAllTags(chatMessage.getName());
+            String formatted = senderName.isEmpty()
+                ? newMessage
+                : senderName + ": " + newMessage;
+            client.addChatMessage(
+                ChatMessageType.GAMEMESSAGE,
+                "",
+                formatted,
+                TRANSLATOR_SENDER
+            );
+            return;
+        }
+
         if(plugin.getConfig().getSelectedLanguage().needsCharImages()) {
             newMessage = insertBr(newMessage, node);// inserts break line so messages are displayed in multiple lines if they are long
         }
@@ -472,7 +490,7 @@ public class ChatCapture
             Colors textColor = chatColorManager.getMessageColor();
             String textToDisplay = transformer.stringToDisplayedString(translation, textColor);
 
-            replaceChatMessage(textToDisplay, node);
+            replaceChatMessage(textToDisplay, node, chatMessage);
             addMsgToSidePanel(chatMessage, translation);
             toRemove.add(pair);
         }

--- a/src/main/java/com/RuneLingual/RuneLingualConfig.java
+++ b/src/main/java/com/RuneLingual/RuneLingualConfig.java
@@ -293,6 +293,17 @@ public interface RuneLingualConfig extends Config {
     }
 
     @ConfigItem(
+            name = "Chat Display Mode",
+            description = "How translated chat messages are displayed. Replace original overwrites the message. Add translator message sends a separate translation below.",
+            position = 8 + offset_section3,
+            keyName = "chatDisplayMode",
+            section = SECTION_CHAT_MESSAGES
+    )
+    default ChatDisplayMode getChatDisplayMode() {
+        return ChatDisplayMode.REPLACE_ORIGINAL;
+    }
+
+    @ConfigItem(
             name = "Me in Public",
             description = "Option for your own messages in Public chat",
             position = 1 + offset_section4,
@@ -464,6 +475,10 @@ public interface RuneLingualConfig extends Config {
     enum chatSelfConfig {
         TRANSFORM,
         LEAVE_AS_IS,
+    }
+    enum ChatDisplayMode {
+        REPLACE_ORIGINAL,
+        ADD_TRANSLATOR_MSG,
     }
 
 }

--- a/src/main/java/com/RuneLingual/SQL/SqlQuery.java
+++ b/src/main/java/com/RuneLingual/SQL/SqlQuery.java
@@ -70,7 +70,7 @@ public class SqlQuery implements Cloneable{
         // P2: english + category + subCategory
         // P3: english + category
         // P4: english only, case-insensitive
-        // P5: fuzzy match (strip all non-alphanumeric chars, compare case-insensitive)
+        // P5: fuzzy match in english (strip all non-alphanumeric chars, compare case-insensitive) + category + subCategory
         // Fallback: placeholder matching (when searchAlike=true)
         english = replaceSpecialSpaces(english);
         String[][] result;
@@ -99,7 +99,7 @@ public class SqlQuery implements Cloneable{
             return extractTranslations(result);
         }
 
-        // P5: fuzzy match - strip spaces/punctuation, compare alphanumeric chars only (case-insensitive)
+        // P5: fuzzy match in english (strip all non-alphanumeric chars, compare case-insensitive) + category + subCategory
         // Handles cases where the database english and actual text differ in spaces or punctuation
         result = getFuzzyMatch(column);
         if (result.length > 0) {
@@ -186,40 +186,33 @@ public class SqlQuery implements Cloneable{
      * This catches cases where the only differences are spaces, punctuation, or letter case.
      */
     private String[][] getFuzzyMatch(SqlVariables column) {
+        // Require both category and subCategory (like P1-P2)
+        if (category == null || category.isEmpty() || subCategory == null || subCategory.isEmpty()) {
+            return new String[0][0];
+        }
+
         String normalizedEnglish = normalizeForFuzzyMatch(english);
         if (normalizedEnglish.isEmpty()) {
             return new String[0][0];
         }
 
-        // Narrow down with category / subCategory when available (no english WHERE clause)
-        List<String> clauses = new ArrayList<>();
-        if (category != null && !category.isEmpty()) {
-            clauses.add(SqlVariables.columnCategory.getColumnName() + " = '" + category.replace("'", "''") + "'");
-        }
-        if (subCategory != null && !subCategory.isEmpty()) {
-            clauses.add(SqlVariables.columnSubCategory.getColumnName() + " = '" + subCategory.replace("'", "''") + "'");
-        }
-
-        String query;
-        if (clauses.isEmpty()) {
-            query = "SELECT english, " + column.getColumnName() + " FROM " + SqlActions.tableName;
-        } else {
-            query = "SELECT english, " + column.getColumnName() + " FROM " + SqlActions.tableName
-                    + " WHERE " + String.join(" AND ", clauses);
-        }
+        // Build query with mandatory category + subCategory
+        String query = "SELECT english, " + column.getColumnName() + " FROM " + SqlActions.tableName
+                + " WHERE " + SqlVariables.columnCategory.getColumnName() + " = '" + category.replace("'", "''") + "'"
+                + " AND " + SqlVariables.columnSubCategory.getColumnName() + " = '" + subCategory.replace("'", "''") + "'";
 
         String[][] results = plugin.getSqlActions().executeSearchQuery(query);
         if (results == null || results.length == 0) {
             return new String[0][0];
         }
 
-        // Java-side comparison on normalized text
+        // Java-side fuzzy comparison on normalized text
         List<String[]> matches = new ArrayList<>();
         for (String[] row : results) {
             if (row.length >= 2 && row[0] != null) {
                 String dbNormalized = normalizeForFuzzyMatch(row[0]);
                 if (dbNormalized.equals(normalizedEnglish)) {
-                    matches.add(new String[]{row[1]}); // the translation column
+                    matches.add(new String[]{row[1]});
                 }
             }
         }

--- a/src/main/java/com/RuneLingual/SQL/SqlQuery.java
+++ b/src/main/java/com/RuneLingual/SQL/SqlQuery.java
@@ -65,25 +65,113 @@ public class SqlQuery implements Cloneable{
     }
 
     public String[] getMatching(SqlVariables column, boolean searchAlike) {
-        // create query -> execute -> return result
-        String query = getSearchQuery();
-        query = query.replace("*", column.getColumnName());
-        String[][] result = plugin.getSqlActions().executeSearchQuery(query);
-        if(result.length == 0 && searchAlike){
+        // Priority-based fallback chain for finding the best matching translation
+        // P1: english + category + subCategory + source (5-tuple exact match)
+        // P2: english + category + subCategory
+        // P3: english + category
+        // P4: english only, exact match
+        // P4.5: english only, case-insensitive
+        // Fallback: placeholder matching (when searchAlike=true)
+        english = replaceSpecialSpaces(english);
+        String[][] result;
+
+        // P1: Full 5-tuple exact match (english + category + subCategory + source)
+        result = searchWithFields(column, true, true, true, false);
+        if (result.length > 0) {
+            return extractTranslations(result);
+        }
+
+        // P2: Relax source constraint (english + category + subCategory)
+        result = searchWithFields(column, true, true, false, false);
+        if (result.length > 0) {
+            return extractTranslations(result);
+        }
+
+        // P3: Relax subCategory constraint (english + category)
+        result = searchWithFields(column, true, false, false, false);
+        if (result.length > 0) {
+            return extractTranslations(result);
+        }
+
+        // P4: english only, exact match
+        result = searchWithFields(column, false, false, false, false);
+        if (result.length > 0) {
+            return extractTranslations(result);
+        }
+
+        // P4.5: english only, case-insensitive match
+        result = searchWithFields(column, false, false, false, true);
+        if (result.length > 0) {
+            return extractTranslations(result);
+        }
+
+        // Final fallback: placeholder matching (only if searchAlike=true)
+        if (searchAlike) {
             return new String[]{getPlaceholderMatches()};
         }
-        if(result.length == 0){
-            // search again ignoring cases
-            query = getSearchQuery_IgnoreCase();
-            query = query.replace("*", column.getColumnName());
-            result = plugin.getSqlActions().executeSearchQuery(query);
+
+        return new String[0];
+    }
+
+    /**
+     * Builds a SELECT query with the specified column constraints and executes it.
+     * @param column The column to select
+     * @param useCat Whether to include category in WHERE clause
+     * @param useSubCat Whether to include subCategory in WHERE clause
+     * @param useSource Whether to include source in WHERE clause
+     * @param ignoreCase Whether to use case-insensitive comparison on English match
+     * @return 2D result array from the query
+     */
+    private String[][] searchWithFields(SqlVariables column, boolean useCat, boolean useSubCat, boolean useSource, boolean ignoreCase) {
+        String query = buildQueryForColumns(useCat, useSubCat, useSource, ignoreCase);
+        if (query == null) {
+            return new String[0][0];
         }
+        query = query.replace("*", column.getColumnName());
+        return plugin.getSqlActions().executeSearchQuery(query);
+    }
+
+    /**
+     * Constructs a SQL SELECT query with the specified column constraints.
+     * The WHERE clause always includes english, and optionally category, subCategory, and source.
+     * @param useCat Whether to include category in WHERE clause
+     * @param useSubCat Whether to include subCategory in WHERE clause
+     * @param useSource Whether to include source in WHERE clause
+     * @param ignoreCase Whether to use case-insensitive comparison on english
+     * @return A complete SQL query string
+     */
+    private String buildQueryForColumns(boolean useCat, boolean useSubCat, boolean useSource, boolean ignoreCase) {
+        List<String> clauses = new ArrayList<>();
+        if (ignoreCase) {
+            clauses.add("UPPER(" + SqlVariables.columnEnglish.getColumnName() + ") = UPPER('" + english.replace("'", "''") + "')");
+        } else {
+            clauses.add(SqlVariables.columnEnglish.getColumnName() + " = '" + english.replace("'", "''") + "'");
+        }
+        if (useCat && category != null && !category.isEmpty()) {
+            clauses.add(SqlVariables.columnCategory.getColumnName() + " = '" + category + "'");
+        }
+        if (useSubCat && subCategory != null && !subCategory.isEmpty()) {
+            clauses.add(SqlVariables.columnSubCategory.getColumnName() + " = '" + subCategory + "'");
+        }
+        if (useSource && source != null && !source.isEmpty()) {
+            clauses.add(SqlVariables.columnSource.getColumnName() + " = '" + source + "'");
+        }
+        return "SELECT * FROM " + SqlActions.tableName + " WHERE " + String.join(" AND ", clauses);
+    }
+
+    /**
+     * Extracts the first column (translation) from each row of a 2D result array.
+     * @param result The 2D result array from a SQL query
+     * @return A 1D array of the first column values
+     */
+    private String[] extractTranslations(String[][] result) {
         String[] translations = new String[result.length];
-        for (int i = 0; i < result.length; i++){
+        for (int i = 0; i < result.length; i++) {
             translations[i] = result[i][0];
         }
         return translations;
     }
+
 
     public String[] getMatching(SqlVariables[] columns) {
         // create query -> execute -> return result
@@ -175,6 +263,7 @@ public class SqlQuery implements Cloneable{
         return str.replaceAll("([\\[\\](){}*+?^$.|])", "\\\\$1");
     }
 
+    @Deprecated
     public String getSearchQuery() {
         english = replaceSpecialSpaces(english);
 
@@ -204,6 +293,7 @@ public class SqlQuery implements Cloneable{
         return null;
     }
 
+    @Deprecated
     public String getSearchQuery_IgnoreCase() {
         english = replaceSpecialSpaces(english);
 

--- a/src/main/java/com/RuneLingual/SQL/SqlQuery.java
+++ b/src/main/java/com/RuneLingual/SQL/SqlQuery.java
@@ -70,6 +70,7 @@ public class SqlQuery implements Cloneable{
         // P2: english + category + subCategory
         // P3: english + category
         // P4: english only, case-insensitive
+        // P5: fuzzy match (strip all non-alphanumeric chars, compare case-insensitive)
         // Fallback: placeholder matching (when searchAlike=true)
         english = replaceSpecialSpaces(english);
         String[][] result;
@@ -98,6 +99,12 @@ public class SqlQuery implements Cloneable{
             return extractTranslations(result);
         }
 
+        // P5: fuzzy match - strip spaces/punctuation, compare alphanumeric chars only (case-insensitive)
+        // Handles cases where the database english and actual text differ in spaces or punctuation
+        result = getFuzzyMatch(column);
+        if (result.length > 0) {
+            return extractTranslations(result);
+        }
         return new String[0];
     }
 
@@ -171,6 +178,61 @@ public class SqlQuery implements Cloneable{
             translations[i] = result[0][0];
         }
         return translations;
+    }
+
+    /**
+     * P5 fuzzy matching: fetch candidate rows from DB, then normalize both sides in Java
+     * by stripping all non-alphanumeric characters and lowercasing.
+     * This catches cases where the only differences are spaces, punctuation, or letter case.
+     */
+    private String[][] getFuzzyMatch(SqlVariables column) {
+        String normalizedEnglish = normalizeForFuzzyMatch(english);
+        if (normalizedEnglish.isEmpty()) {
+            return new String[0][0];
+        }
+
+        // Narrow down with category / subCategory when available (no english WHERE clause)
+        List<String> clauses = new ArrayList<>();
+        if (category != null && !category.isEmpty()) {
+            clauses.add(SqlVariables.columnCategory.getColumnName() + " = '" + category.replace("'", "''") + "'");
+        }
+        if (subCategory != null && !subCategory.isEmpty()) {
+            clauses.add(SqlVariables.columnSubCategory.getColumnName() + " = '" + subCategory.replace("'", "''") + "'");
+        }
+
+        String query;
+        if (clauses.isEmpty()) {
+            query = "SELECT english, " + column.getColumnName() + " FROM " + SqlActions.tableName;
+        } else {
+            query = "SELECT english, " + column.getColumnName() + " FROM " + SqlActions.tableName
+                    + " WHERE " + String.join(" AND ", clauses);
+        }
+
+        String[][] results = plugin.getSqlActions().executeSearchQuery(query);
+        if (results == null || results.length == 0) {
+            return new String[0][0];
+        }
+
+        // Java-side comparison on normalized text
+        List<String[]> matches = new ArrayList<>();
+        for (String[] row : results) {
+            if (row.length >= 2 && row[0] != null) {
+                String dbNormalized = normalizeForFuzzyMatch(row[0]);
+                if (dbNormalized.equals(normalizedEnglish)) {
+                    matches.add(new String[]{row[1]}); // the translation column
+                }
+            }
+        }
+        return matches.toArray(new String[0][0]);
+    }
+
+    /**
+     * Keep only letters (a-z, A-Z) and digits (0-9), lowercase everything.
+     * Used by P5 to compare text ignoring spaces, punctuation, and case differences.
+     */
+    private static String normalizeForFuzzyMatch(String str) {
+        if (str == null) return "";
+        return str.replaceAll("[^a-zA-Z0-9]", "").toLowerCase();
     }
 
     @Deprecated

--- a/src/main/java/com/RuneLingual/SQL/SqlQuery.java
+++ b/src/main/java/com/RuneLingual/SQL/SqlQuery.java
@@ -64,13 +64,12 @@ public class SqlQuery implements Cloneable{
         }
     }
 
-    public String[] getMatching(SqlVariables column, boolean searchAlike) {
+    public String[] getMatching(SqlVariables column, @Deprecated boolean searchAlike) {
         // Priority-based fallback chain for finding the best matching translation
         // P1: english + category + subCategory + source (5-tuple exact match)
         // P2: english + category + subCategory
         // P3: english + category
-        // P4: english only, exact match
-        // P4.5: english only, case-insensitive
+        // P4: english only, case-insensitive
         // Fallback: placeholder matching (when searchAlike=true)
         english = replaceSpecialSpaces(english);
         String[][] result;
@@ -93,21 +92,10 @@ public class SqlQuery implements Cloneable{
             return extractTranslations(result);
         }
 
-        // P4: english only, exact match
-        result = searchWithFields(column, false, false, false, false);
-        if (result.length > 0) {
-            return extractTranslations(result);
-        }
-
-        // P4.5: english only, case-insensitive match
+        // P4: english only, case-insensitive match
         result = searchWithFields(column, false, false, false, true);
         if (result.length > 0) {
             return extractTranslations(result);
-        }
-
-        // Final fallback: placeholder matching (only if searchAlike=true)
-        if (searchAlike) {
-            return new String[]{getPlaceholderMatches()};
         }
 
         return new String[0];
@@ -185,6 +173,7 @@ public class SqlQuery implements Cloneable{
         return translations;
     }
 
+    @Deprecated
     private String getPlaceholderMatches(){
         /*
         returns translation which includes placeholders at first that matches the english text,
@@ -323,6 +312,7 @@ public class SqlQuery implements Cloneable{
         return null;
     }
 
+    @Deprecated
     public String getPlaceholderSearchQuery(String[] placeholders) {
         // creates query that matches all non-empty fields
         // returns null if no fields are filled

--- a/src/main/java/com/RuneLingual/Widgets/DialogTranslator.java
+++ b/src/main/java/com/RuneLingual/Widgets/DialogTranslator.java
@@ -25,8 +25,6 @@ import static com.RuneLingual.Widgets.WidgetsUtilRLingual.removeBrAndTags;
 
 @Slf4j
 public class DialogTranslator {
-    // Dialog happens in a separate widget than the ChatBox itself
-    // not limited to npc conversations themselves, but also chat actions
     @Inject
     private Client client;
     @Inject
@@ -34,7 +32,6 @@ public class DialogTranslator {
     @Inject
     private RuneLingualConfig config;
 
-    // player widget ids
     @Getter
     private final int playerNameWidgetId = ChatRight.NAME;
     @Getter
@@ -42,7 +39,6 @@ public class DialogTranslator {
     @Getter
     private final int playerContentWidgetId = ChatRight.TEXT;
 
-    // npc widget ids
     @Getter
     private final int npcNameWidgetId = ChatLeft.NAME;
     @Getter
@@ -50,10 +46,10 @@ public class DialogTranslator {
     @Getter
     private final int npcContentWidgetId = ChatLeft.TEXT;
 
-    // dialog option widget ids
     @Getter
-    private final int dialogOptionWidgetId = Chatmenu.OPTIONS; // each and every line of the option dialogue has this id, even the red "select an option" text
+    private final int dialogOptionWidgetId = Chatmenu.OPTIONS;
 
+    private static final String PLAYER_NAME_PLACEHOLDER = "[player name]";
 
     private final Colors defaultTextColor = Colors.black;
     private final Colors continueTextColor = Colors.blue;
@@ -81,6 +77,28 @@ public class DialogTranslator {
         this.transformer = new Transformer(plugin);
     }
 
+    private String replacePlayerNameWithPlaceholder(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        String playerName = client.getLocalPlayer().getName();
+        if (playerName == null || playerName.isEmpty()) {
+            return text;
+        }
+        return text.replace(playerName, PLAYER_NAME_PLACEHOLDER);
+    }
+
+    private String restorePlayerName(String translatedText) {
+        if (translatedText == null || !translatedText.contains(PLAYER_NAME_PLACEHOLDER)) {
+            return translatedText;
+        }
+        String playerName = client.getLocalPlayer().getName();
+        if (playerName == null) {
+            return translatedText;
+        }
+        return translatedText.replace(PLAYER_NAME_PLACEHOLDER, playerName);
+    }
+
     public void handleDialogs(Widget widget) {
         if(widget.getText().contains("<img=")) {
             return;
@@ -94,29 +112,27 @@ public class DialogTranslator {
 
         int interfaceID = WidgetUtil.componentToInterface(widget.getId());
 
-        // if the widget is the npc name widget, and the config is set to use api translation
         if (npcNameOption.equals(TransformOption.TRANSLATE_API) && widget.getId() == npcNameWidgetId) {
             String npcName = widget.getText();
             widgetsUtilRLingual.setWidgetText_ApiTranslation(widget, npcName, nameAndSelectOptionTextColor);
             return;
         }
-        // if the widget is not npc name nor player name, and the config is set to use api translation
         else if (dialogOption.equals(TransformOption.TRANSLATE_API) && widget.getId() != playerNameWidgetId && widget.getId() != npcNameWidgetId) {
             String dialogText = widget.getText();
             if(dialogText.isEmpty()) {
                 return;
             }
+            String textForTranslation = replacePlayerNameWithPlaceholder(dialogText);
             Colors[] textColor = {defaultTextColor};
             if(widget.getId() == npcContinueWidgetId || widget.getId() == playerContinueWidgetId)
                 textColor[0] = continueTextColor;
             else if(widget.getId() == dialogOptionWidgetId && widget.getText().equals(selectOptionText))
                 textColor[0] = nameAndSelectOptionTextColor;
 
-            widgetsUtilRLingual.setWidgetText_ApiTranslation(widget, dialogText, textColor[0]);
+            widgetsUtilRLingual.setWidgetText_ApiTranslation(widget, textForTranslation, textColor[0]);
             return;
         }
 
-        // is not api translation
         switch (interfaceID) {
             case InterfaceID.DIALOG_NPC:
                 handleNpcDialog(widget);
@@ -130,10 +146,8 @@ public class DialogTranslator {
             default:
                 break;
         }
-        //log.info("Unknown dialog widget: " + widget.getId());
     }
 
-    // is not api translation
     private void handleNpcDialog(Widget widget) {
         if (widget.getId() == npcNameWidgetId) {
             String npcName = widget.getText();
@@ -147,43 +161,48 @@ public class DialogTranslator {
         } else if (widget.getId() == npcContinueWidgetId) {
             translateContinueWidget(widget);
         } else if (widget.getId() == npcContentWidgetId) {
-            String npcContent = widget.getText(); // this can contain tags like <br> and probably color tags
+            String npcContent = widget.getText();
             npcContent = removeBrAndTags(npcContent);
+
+            String npcContentForQuery = replacePlayerNameWithPlaceholder(npcContent);
+
             String npcName = getInteractingNpcName();
             SqlQuery query = new SqlQuery(this.plugin);
-            query.setDialogue(npcContent, npcName, false, defaultTextColor);
-            String translatedText = transformer.transform(npcContent, defaultTextColor, dialogOption, query, false);
+            query.setDialogue(npcContentForQuery, npcName, false, defaultTextColor);
+            String translatedText = transformer.transform(npcContentForQuery, defaultTextColor, dialogOption, query, false);
+
+            translatedText = restorePlayerName(translatedText);
+
             widgetsUtilRLingual.setWidgetText_NiceBr(widget, translatedText);
             widgetsUtilRLingual.changeLineHeight(widget);
         }
     }
 
-    // is not api translation
     private void handlePlayerDialog(Widget widget) {
         if (widget.getId() == playerContinueWidgetId) {
-            //log.info(widget.getText());
             translateContinueWidget(widget);
             return;
         }
         if (widget.getId() == playerContentWidgetId) {
-            String playerContent = widget.getText(); // this can contain tags like <br> and probably color tags
+            String playerContent = widget.getText();
             playerContent = removeBrAndTags(playerContent);
 
+            String playerContentForQuery = replacePlayerNameWithPlaceholder(playerContent);
 
             String npcName = getInteractingNpcName();
-            //log.info("playerContent: " + playerContent + " with npc: " + npcName);
 
             SqlQuery query = new SqlQuery(this.plugin);
-            query.setDialogue(playerContent, npcName, true, defaultTextColor);
-            String translatedText = transformer.transform(playerContent, defaultTextColor, dialogOption, query, false);
+            query.setDialogue(playerContentForQuery, npcName, true, defaultTextColor);
+            String translatedText = transformer.transform(playerContentForQuery, defaultTextColor, dialogOption, query, false);
+
+            translatedText = restorePlayerName(translatedText);
+
             widgetsUtilRLingual.setWidgetText_NiceBr(widget, translatedText);
             widgetsUtilRLingual.changeLineHeight(widget);
         }
-        // player name does not need to be translated
     }
 
     private void handleOptionDialog(Widget widget) {
-        // the red "Select an option" text is not tagged with red color
         String dialogOption = widget.getText();
         if (dialogOption.equals(selectOptionText)) {
             widget.setText(getSelectOptionTranslation());
@@ -194,9 +213,15 @@ public class DialogTranslator {
             return;
         }
         dialogOption = removeBrAndTags(dialogOption);
+
+        String dialogOptionForQuery = replacePlayerNameWithPlaceholder(dialogOption);
+
         SqlQuery query = new SqlQuery(this.plugin);
-        query.setDialogue(dialogOption, getInteractingNpcName(), false, defaultTextColor);
-        String translatedText = transformer.transform(dialogOption, defaultTextColor, this.dialogOption, query, false);
+        query.setDialogue(dialogOptionForQuery, getInteractingNpcName(), false, defaultTextColor);
+        String translatedText = transformer.transform(dialogOptionForQuery, defaultTextColor, this.dialogOption, query, false);
+
+        translatedText = restorePlayerName(translatedText);
+
         widgetsUtilRLingual.setWidgetText_NiceBr(widget, translatedText);
         widgetsUtilRLingual.changeLineHeight(widget);
     }

--- a/src/main/java/com/RuneLingual/Widgets/DialogTranslator.java
+++ b/src/main/java/com/RuneLingual/Widgets/DialogTranslator.java
@@ -89,18 +89,7 @@ public class DialogTranslator {
     }
 
     private String restorePlayerName(String translatedText) {
-        if (translatedText == null) {
-            return null;
-        }
-        String playerName = client.getLocalPlayer().getName();
-        if (playerName == null) {
-            return translatedText;
-        }
-        // Handle plain placeholder and <asis> wrapped placeholder
-        translatedText = translatedText.replace("<asis>" + PLAYER_NAME_PLACEHOLDER + "</asis>", playerName);
-        translatedText = translatedText.replace(PLAYER_NAME_PLACEHOLDER, playerName);
-        // Clean up any lingering <asis> tags
-        translatedText = translatedText.replace("<asis>", "").replace("</asis>", "");
+        // Player name restoration now happens in Transformer.stringToDisplayedString
         return translatedText;
     }
 

--- a/src/main/java/com/RuneLingual/Widgets/DialogTranslator.java
+++ b/src/main/java/com/RuneLingual/Widgets/DialogTranslator.java
@@ -89,14 +89,19 @@ public class DialogTranslator {
     }
 
     private String restorePlayerName(String translatedText) {
-        if (translatedText == null || !translatedText.contains(PLAYER_NAME_PLACEHOLDER)) {
-            return translatedText;
+        if (translatedText == null) {
+            return null;
         }
         String playerName = client.getLocalPlayer().getName();
         if (playerName == null) {
             return translatedText;
         }
-        return translatedText.replace(PLAYER_NAME_PLACEHOLDER, playerName);
+        // Handle plain placeholder and <asis> wrapped placeholder
+        translatedText = translatedText.replace("<asis>" + PLAYER_NAME_PLACEHOLDER + "</asis>", playerName);
+        translatedText = translatedText.replace(PLAYER_NAME_PLACEHOLDER, playerName);
+        // Clean up any lingering <asis> tags
+        translatedText = translatedText.replace("<asis>", "").replace("</asis>", "");
+        return translatedText;
     }
 
     public void handleDialogs(Widget widget) {

--- a/src/main/java/com/RuneLingual/commonFunctions/Transformer.java
+++ b/src/main/java/com/RuneLingual/commonFunctions/Transformer.java
@@ -262,11 +262,6 @@ public class Transformer {
                 return Colors.surroundWithColorTag(text,colors);
             }
         }
-        // Restore player name before stringToDisplayedString (which may convert it to char images)
-        if (plugin.getClient().getLocalPlayer() != null && plugin.getClient().getLocalPlayer().getName() != null) {
-            String playerName = plugin.getClient().getLocalPlayer().getName();
-            translatedText = translatedText.replace("[player name]", playerName);
-        }
         return stringToDisplayedString(translatedText, colors);
     }
 
@@ -355,10 +350,24 @@ public class Transformer {
     public String stringToDisplayedString(String translatedText, Colors colors){
         boolean needCharImage = plugin.getConfig().getSelectedLanguage().needsCharImages();
         GeneralFunctions generalFunctions = plugin.getGeneralFunctions();
-
-        if(needCharImage) {// needs char image but just 1 color
-            return generalFunctions.StringToTags(Colors.removeNonImgTags(translatedText), colors);
-        } else { // doesnt need char image and just 1 color
+        String playerName = null;
+        if (plugin.getClient().getLocalPlayer() != null && plugin.getClient().getLocalPlayer().getName() != null) {
+            playerName = plugin.getClient().getLocalPlayer().getName();
+        }
+        if(needCharImage) {
+            String cleanedText = Colors.removeNonImgTags(translatedText);
+            if (playerName != null) {
+                cleanedText = cleanedText.replace("[player name]", "<asis>[player name]</asis>");
+            }
+            String tagged = generalFunctions.StringToTags(cleanedText, colors);
+            if (playerName != null) {
+                tagged = tagged.replace("[player name]", playerName);
+            }
+            return tagged;
+        } else {
+            if (playerName != null) {
+                translatedText = translatedText.replace("[player name]", playerName);
+            }
             return "<col=" + colors.getHex() + ">" + translatedText + "</col>";
         }
     }

--- a/src/main/java/com/RuneLingual/commonFunctions/Transformer.java
+++ b/src/main/java/com/RuneLingual/commonFunctions/Transformer.java
@@ -262,6 +262,11 @@ public class Transformer {
                 return Colors.surroundWithColorTag(text,colors);
             }
         }
+        // Restore player name before stringToDisplayedString (which may convert it to char images)
+        if (plugin.getClient().getLocalPlayer() != null && plugin.getClient().getLocalPlayer().getName() != null) {
+            String playerName = plugin.getClient().getLocalPlayer().getName();
+            translatedText = translatedText.replace("[player name]", playerName);
+        }
         return stringToDisplayedString(translatedText, colors);
     }
 


### PR DESCRIPTION
1. Add [player name] placeholder support and also the player name will show in plain text for non-latin language. Example: 
English: How are you, [player name]?
Translation (Chinese): 你好嗎，[player name]? (If player name is TestingName)
In game: 你好嗎，TestingName?

2.  Replace exact-match query with priority-based fallback chain
P1: english + category + subCategory + source  (most precise)
P2: english + category + subCategory
P3: english + category
P4: english only, case-insensitive
P5: english only, fuzzy (strips all spaces/punctuation, compares letters+digits only)

3. Add ChatDisplayMode toggle (REPLACE_ORIGINAL / ADD_TRANSLATOR_MSG)]
<img width="256" height="249" alt="image" src="https://github.com/user-attachments/assets/5c4e9b4f-29e2-42ac-aaf1-176b7f2f3701" />
REPLACE_ORIGINAL mode and ADD_TRANSLATOR_MSG mode
<img width="775" height="62" alt="image" src="https://github.com/user-attachments/assets/71fed6ac-914d-4207-8b2e-d8705ef8a51e" />

4. Update README_developers.md with fallback chain docs